### PR TITLE
fix: Build with -trimpath and add macOS notarize

### DIFF
--- a/.github/workflows/parity.yml
+++ b/.github/workflows/parity.yml
@@ -1,3 +1,5 @@
+# Parity workflow: CI parity checks and build artifacts for PRs, pushes, schedules,
+# and manual preview builds.
 name: parity
 
 on:
@@ -5,6 +7,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
   schedule:
     - cron: "0 9 * * 1"
 
@@ -95,7 +98,7 @@ jobs:
           CGO_ENABLED: "0"
         run: |
           mkdir -p dist
-          go build -o "dist/apprise-go-${GOOS}-${GOARCH}" ./cmd/apprise
+          go build -trimpath -ldflags "-s -w" -o "dist/apprise-go-${GOOS}-${GOARCH}" ./cmd/apprise
 
       - name: Upload binary artifact
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,10 @@
+# Release workflow: publish signed/notarized release assets.
+# Preview/CI artifacts are handled by parity.yml.
 name: release
 
 on:
   release:
     types: [published]
-  workflow_dispatch:
 
 permissions:
   contents: write
@@ -17,8 +18,10 @@ jobs:
         include:
           - goos: linux
             goarch: amd64
+            notarize: false
           - goos: linux
             goarch: arm64
+            notarize: false
           - goos: darwin
             goarch: amd64
             notarize: true
@@ -41,7 +44,7 @@ jobs:
           CGO_ENABLED: "0"
         run: |
           mkdir -p dist
-          go build -o "dist/apprise-go-${GOOS}-${GOARCH}" ./cmd/apprise
+          go build -trimpath -ldflags "-s -w" -o "dist/apprise-go-${GOOS}-${GOARCH}" ./cmd/apprise
 
       - name: Write signing certificate
         if: matrix.notarize
@@ -59,13 +62,27 @@ jobs:
           printf '%s' "$APP_STORE_CONNECT_KEY_JSON" > app_store_connect_key.json
           chmod 600 app_store_connect_key.json
 
-      - name: Sign and notarize darwin binary
+      - name: Sign darwin binary
         if: matrix.notarize
         uses: indygreg/apple-code-sign-action@v1
         with:
           input_path: dist/apprise-go-${{ matrix.goos }}-${{ matrix.goarch }}
           p12_file: apple_codesign.p12
           p12_password: ${{ secrets.APPLE_BUILD_CERTIFICATE_PASSWORD }}
+          notarize: false
+
+      - name: Zip darwin binary
+        if: matrix.notarize
+        run: |
+          zip -j "dist/apprise-go-${{ matrix.goos }}-${{ matrix.goarch }}.zip" \
+            "dist/apprise-go-${{ matrix.goos }}-${{ matrix.goarch }}"
+
+      - name: Notarize darwin zip
+        if: matrix.notarize
+        uses: indygreg/apple-code-sign-action@v1
+        with:
+          input_path: dist/apprise-go-${{ matrix.goos }}-${{ matrix.goarch }}.zip
+          sign: false
           notarize: true
           app_store_connect_api_key_json_file: app_store_connect_key.json
 
@@ -73,15 +90,14 @@ jobs:
         if: always()
         run: rm -f apple_codesign.p12 app_store_connect_key.json
 
-      - name: Upload release asset
-        if: github.event_name == 'release'
+      - name: Upload release asset (darwin zip)
+        if: github.event_name == 'release' && matrix.notarize
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/apprise-go-${{ matrix.goos }}-${{ matrix.goarch }}.zip
+
+      - name: Upload release asset (non-darwin)
+        if: github.event_name == 'release' && !matrix.notarize
         uses: softprops/action-gh-release@v2
         with:
           files: dist/apprise-go-${{ matrix.goos }}-${{ matrix.goarch }}
-
-      - name: Upload artifact
-        if: github.event_name != 'release'
-        uses: actions/upload-artifact@v6
-        with:
-          name: apprise-go-${{ matrix.goos }}-${{ matrix.goarch }}
-          path: dist/apprise-go-${{ matrix.goos }}-${{ matrix.goarch }}


### PR DESCRIPTION
- Use -trimpath and -ldflags "-s -w" on all builds
- Sign, zip, and notarize macOS binaries
- Gate notarization per matrix and adjust release artifact uploads
- Mark Linux builds to skip notarization via matrix.notarize

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Produced smaller, stripped binaries to reduce release file sizes.
  * Reworked macOS signing/notarization: macOS artifacts are zipped and notarized as ZIPs; signing and cleanup improved.
  * Split release uploads: macOS ZIPs and non-macOS raw binaries are handled separately.
  * CI adjustment: added manual trigger for parity workflow and removed manual trigger from the release workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->