### PR TITLE
fix: enable hardened runtime for macos signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,7 @@ jobs:
           input_path: dist/apprise-go-${{ matrix.goos }}-${{ matrix.goarch }}
           p12_file: apple_codesign.p12
           p12_password: ${{ secrets.APPLE_BUILD_CERTIFICATE_PASSWORD }}
+          sign_args: --code-signature-flags runtime
           notarize: false
 
       - name: Zip darwin binary


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved macOS binary release process to ensure proper code signing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->