### PR TITLE
fix: config tag group resolution

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,3 +7,5 @@ require (
 	golang.org/x/crypto v0.51.0
 	golang.org/x/net v0.54.0
 )
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -18,3 +18,7 @@ golang.org/x/net v0.49.0 h1:eeHFmOGUTtaaPSGNmjBKpbng9MulQsJURQUAfUwY++o=
 golang.org/x/net v0.49.0/go.mod h1:/ysNB2EvaqvesRkuLAyjI1ycPZlQHM3q01F02UY/MV8=
 golang.org/x/net v0.54.0 h1:2zJIZAxAHV/OHCDTCOHAYehQzLfSXuf/5SoL/Dv6w/w=
 golang.org/x/net v0.54.0/go.mod h1:Sj4oj8jK6XmHpBZU/zWHw3BV3abl4Kvi+Ut7cQcY+cQ=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -2,10 +2,14 @@ package cli
 
 import (
 	"bufio"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -25,6 +29,11 @@ type taggedURL struct {
 	Tags []string
 }
 
+type parsedConfig struct {
+	URLs   []taggedURL
+	Groups map[string][]string
+}
+
 func loadTaggedURLs(configPaths []string) []taggedURL {
 	urls := []taggedURL{}
 	for _, path := range configPaths {
@@ -42,28 +51,66 @@ func loadTaggedURLs(configPaths []string) []taggedURL {
 }
 
 func parseConfigFile(path string) []taggedURL {
-	handle, err := os.Open(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
 	}
-	defer handle.Close()
+	if isYAMLConfigPath(path) {
+		if parsed := parseYAMLConfig(data); len(parsed.URLs) > 0 || len(parsed.Groups) > 0 {
+			return applyTagGroups(parsed.URLs, parsed.Groups)
+		}
+	}
+	parsed := parseTextConfig(string(data))
+	return applyTagGroups(parsed.URLs, parsed.Groups)
+}
 
-	var urls []taggedURL
-	scanner := bufio.NewScanner(handle)
+func parseTextConfig(raw string) parsedConfig {
+	cfg := parsedConfig{
+		URLs:   []taggedURL{},
+		Groups: map[string][]string{},
+	}
+
+	scanner := bufio.NewScanner(strings.NewReader(raw))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 
+		if groups, tags, ok := parseGroupAssignment(line); ok {
+			for _, group := range groups {
+				cfg.Groups[group] = append(cfg.Groups[group], tags...)
+			}
+			continue
+		}
+
 		if parsed := parseTaggedLine(line); len(parsed) > 0 {
-			urls = append(urls, parsed...)
+			cfg.URLs = append(cfg.URLs, parsed...)
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return urls
+		return cfg
 	}
-	return urls
+	return cfg
+}
+
+func parseYAMLConfig(data []byte) parsedConfig {
+	var root any
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		return parsedConfig{URLs: []taggedURL{}, Groups: map[string][]string{}}
+	}
+
+	rootMap, ok := asStringMap(root)
+	if !ok {
+		return parsedConfig{URLs: []taggedURL{}, Groups: map[string][]string{}}
+	}
+
+	globalTags := parseYAMLTags(rootMap)
+	cfg := parsedConfig{
+		URLs:   parseYAMLURLs(rootMap["urls"], globalTags),
+		Groups: parseYAMLGroups(rootMap["groups"]),
+	}
+	return cfg
 }
 
 func parseTaggedLine(line string) []taggedURL {
@@ -73,8 +120,8 @@ func parseTaggedLine(line string) []taggedURL {
 	if strings.Contains(line, "=") {
 		parts := strings.SplitN(line, "=", 2)
 		tagPart := strings.TrimSpace(parts[0])
-		raw = strings.TrimSpace(parts[1])
-		if tagPart != "" && !strings.Contains(tagPart, "://") {
+		if tagPart != "" && !urlSchemeRe.MatchString(tagPart) {
+			raw = strings.TrimSpace(parts[1])
 			tags = parseTags(tagPart)
 		}
 	}
@@ -94,6 +141,24 @@ func parseTaggedLine(line string) []taggedURL {
 	return result
 }
 
+func parseGroupAssignment(line string) ([]string, []string, bool) {
+	if !strings.Contains(line, "=") {
+		return nil, nil, false
+	}
+	parts := strings.SplitN(line, "=", 2)
+	left := strings.TrimSpace(parts[0])
+	right := strings.TrimSpace(parts[1])
+	if left == "" || right == "" || urlSchemeRe.MatchString(left) || urlSchemeRe.MatchString(right) {
+		return nil, nil, false
+	}
+	groups := parseTags(left)
+	tags := parseTags(right)
+	if len(groups) == 0 || len(tags) == 0 {
+		return nil, nil, false
+	}
+	return groups, tags, true
+}
+
 func detectURLs(raw string) []string {
 	matches := urlSchemeRe.FindAllStringIndex(raw, -1)
 	if len(matches) > 0 {
@@ -106,9 +171,6 @@ func detectURLs(raw string) []string {
 			}
 			chunk := strings.TrimSpace(raw[start:end])
 			chunk = strings.TrimRight(chunk, ",")
-			if chunk == "" {
-				continue
-			}
 			urls = append(urls, chunk)
 		}
 		return urls
@@ -206,6 +268,304 @@ func matchesTagFilters(tags []string, filters [][]string) bool {
 		}
 	}
 	return false
+}
+
+func applyTagGroups(urls []taggedURL, groups map[string][]string) []taggedURL {
+	if len(urls) == 0 || len(groups) == 0 {
+		return urls
+	}
+
+	expandedGroups := normalizeTagGroups(groups)
+	for idx := range urls {
+		tagSet := make(map[string]struct{}, len(urls[idx].Tags)+len(expandedGroups))
+		for _, tag := range urls[idx].Tags {
+			if tag == "" {
+				continue
+			}
+			tagSet[strings.ToLower(tag)] = struct{}{}
+		}
+		for group, tags := range expandedGroups {
+			if len(tags) == 0 {
+				continue
+			}
+			for tag := range tagSet {
+				if _, ok := tags[tag]; ok {
+					tagSet[group] = struct{}{}
+					break
+				}
+			}
+		}
+		urls[idx].Tags = sortedTagSet(tagSet)
+	}
+	return urls
+}
+
+func normalizeTagGroups(groups map[string][]string) map[string]map[string]struct{} {
+	groupNames := make(map[string]struct{}, len(groups))
+	for group := range groups {
+		groupNames[group] = struct{}{}
+	}
+
+	expanded := make(map[string]map[string]struct{}, len(groups))
+	var expand func(group string, seen map[string]struct{}) map[string]struct{}
+	expand = func(group string, seen map[string]struct{}) map[string]struct{} {
+		if tags, ok := expanded[group]; ok {
+			return tags
+		}
+		if _, ok := seen[group]; ok {
+			return map[string]struct{}{}
+		}
+		seen[group] = struct{}{}
+		tags := map[string]struct{}{}
+		for _, rawTag := range groups[group] {
+			tag := strings.ToLower(strings.TrimSpace(rawTag))
+			if tag == "" || tag == group {
+				continue
+			}
+			if _, isGroup := groupNames[tag]; isGroup {
+				for expandedTag := range expand(tag, cloneTagSet(seen)) {
+					tags[expandedTag] = struct{}{}
+				}
+				continue
+			}
+			tags[tag] = struct{}{}
+		}
+		expanded[group] = tags
+		return tags
+	}
+
+	for group := range groups {
+		expand(group, map[string]struct{}{})
+	}
+	return expanded
+}
+
+func cloneTagSet(tags map[string]struct{}) map[string]struct{} {
+	cloned := make(map[string]struct{}, len(tags))
+	for tag := range tags {
+		cloned[tag] = struct{}{}
+	}
+	return cloned
+}
+
+func sortedTagSet(tagSet map[string]struct{}) []string {
+	if len(tagSet) == 0 {
+		return nil
+	}
+	tags := make([]string, 0, len(tagSet))
+	for tag := range tagSet {
+		tags = append(tags, tag)
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+func isYAMLConfigPath(path string) bool {
+	switch strings.ToLower(filepath.Ext(path)) {
+	case ".yaml", ".yml":
+		return true
+	default:
+		return false
+	}
+}
+
+func parseYAMLURLs(value any, globalTags []string) []taggedURL {
+	switch urls := value.(type) {
+	case []any:
+		parsed := []taggedURL{}
+		for _, entry := range urls {
+			parsed = append(parsed, parseYAMLURLEntry(entry, globalTags)...)
+		}
+		return parsed
+	case map[string]any:
+		parsed := []taggedURL{}
+		for key, options := range urls {
+			parsed = append(parsed, taggedURL{
+				URL:  strings.TrimSpace(key),
+				Tags: mergeTags(globalTags, parseYAMLTagsFromOptions(options)),
+			})
+		}
+		return parsed
+	default:
+		return nil
+	}
+}
+
+func parseYAMLURLEntry(entry any, globalTags []string) []taggedURL {
+	switch value := entry.(type) {
+	case string:
+		urls := detectURLs(value)
+		parsed := make([]taggedURL, 0, len(urls))
+		for _, url := range urls {
+			parsed = append(parsed, taggedURL{URL: url, Tags: mergeTags(globalTags, nil)})
+		}
+		return parsed
+	case map[string]any:
+		if rawURL, ok := value["url"]; ok {
+			return parseYAMLURLValue(rawURL, mergeTags(globalTags, parseYAMLTags(value)))
+		}
+		if rawURL, ok := value["urls"]; ok {
+			return parseYAMLURLValue(rawURL, mergeTags(globalTags, parseYAMLTags(value)))
+		}
+		parsed := []taggedURL{}
+		for key, options := range value {
+			if !urlSchemeRe.MatchString(key) {
+				continue
+			}
+			parsed = append(parsed, taggedURL{
+				URL:  strings.TrimSpace(key),
+				Tags: mergeTags(globalTags, parseYAMLTagsFromOptions(options)),
+			})
+		}
+		return parsed
+	default:
+		return nil
+	}
+}
+
+func parseYAMLURLValue(value any, tags []string) []taggedURL {
+	switch urls := value.(type) {
+	case string:
+		detected := detectURLs(urls)
+		parsed := make([]taggedURL, 0, len(detected))
+		for _, url := range detected {
+			parsed = append(parsed, taggedURL{URL: url, Tags: mergeTags(tags, nil)})
+		}
+		return parsed
+	case []any:
+		parsed := []taggedURL{}
+		for _, entry := range urls {
+			for _, parsedEntry := range parseYAMLURLValue(entry, tags) {
+				parsed = append(parsed, parsedEntry)
+			}
+		}
+		return parsed
+	default:
+		return nil
+	}
+}
+
+func parseYAMLGroups(value any) map[string][]string {
+	groups := map[string][]string{}
+	switch entries := value.(type) {
+	case map[string]any:
+		for group, rawTags := range entries {
+			for _, parsedGroup := range parseTags(group) {
+				groups[parsedGroup] = append(groups[parsedGroup], parseYAMLGroupTags(rawTags)...)
+			}
+		}
+	case []any:
+		for _, entry := range entries {
+			entryMap, ok := asStringMap(entry)
+			if !ok {
+				continue
+			}
+			for group, rawTags := range entryMap {
+				for _, parsedGroup := range parseTags(group) {
+					groups[parsedGroup] = append(groups[parsedGroup], parseYAMLGroupTags(rawTags)...)
+				}
+			}
+		}
+	}
+	return groups
+}
+
+func parseYAMLGroupTags(value any) []string {
+	switch tags := value.(type) {
+	case nil:
+		return nil
+	case string:
+		return parseTags(tags)
+	case int, int64, float64, bool:
+		return parseTags(fmt.Sprint(tags))
+	case []any:
+		parsed := []string{}
+		for _, entry := range tags {
+			entryMap, ok := asStringMap(entry)
+			if ok {
+				for tag := range entryMap {
+					parsed = append(parsed, parseTags(tag)...)
+				}
+				continue
+			}
+			parsed = append(parsed, parseYAMLGroupTags(entry)...)
+		}
+		return parsed
+	case map[string]any:
+		parsed := []string{}
+		for tag := range tags {
+			parsed = append(parsed, parseTags(tag)...)
+		}
+		return parsed
+	default:
+		return parseTags(fmt.Sprint(tags))
+	}
+}
+
+func parseYAMLTags(value map[string]any) []string {
+	if rawTags, ok := value["tag"]; ok {
+		return parseYAMLTagValue(rawTags)
+	}
+	if rawTags, ok := value["tags"]; ok {
+		return parseYAMLTagValue(rawTags)
+	}
+	return nil
+}
+
+func parseYAMLTagsFromOptions(options any) []string {
+	switch value := options.(type) {
+	case map[string]any:
+		return parseYAMLTags(value)
+	case []any:
+		tags := []string{}
+		for _, entry := range value {
+			if entryMap, ok := asStringMap(entry); ok {
+				tags = append(tags, parseYAMLTags(entryMap)...)
+			}
+		}
+		return tags
+	default:
+		return nil
+	}
+}
+
+func parseYAMLTagValue(value any) []string {
+	switch tags := value.(type) {
+	case nil:
+		return nil
+	case string:
+		return parseTags(tags)
+	case int, int64, float64, bool:
+		return parseTags(fmt.Sprint(tags))
+	case []any:
+		parsed := []string{}
+		for _, entry := range tags {
+			parsed = append(parsed, parseYAMLTagValue(entry)...)
+		}
+		return parsed
+	default:
+		return parseTags(fmt.Sprint(tags))
+	}
+}
+
+func asStringMap(value any) (map[string]any, bool) {
+	if typed, ok := value.(map[string]any); ok {
+		return typed, true
+	}
+	return nil, false
+}
+
+func mergeTags(groups ...[]string) []string {
+	tagSet := map[string]struct{}{}
+	for _, group := range groups {
+		for _, tag := range group {
+			if tag == "" {
+				continue
+			}
+			tagSet[strings.ToLower(tag)] = struct{}{}
+		}
+	}
+	return sortedTagSet(tagSet)
 }
 
 func loadConfigPaths(explicit []string) []string {

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -457,9 +457,7 @@ func parseYAMLURLValue(value any, tags []string) []taggedURL {
 	case []any:
 		parsed := []taggedURL{}
 		for _, entry := range urls {
-			for _, parsedEntry := range parseYAMLURLValue(entry, tags) {
-				parsed = append(parsed, parsedEntry)
-			}
+			parsed = append(parsed, parseYAMLURLValue(entry, tags)...)
 		}
 		return parsed
 	default:

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -380,10 +380,10 @@ func parseYAMLURLs(value any, globalTags []string) []taggedURL {
 	case map[string]any:
 		parsed := []taggedURL{}
 		for key, options := range urls {
-			parsed = append(parsed, taggedURL{
-				URL:  strings.TrimSpace(key),
-				Tags: mergeTags(globalTags, parseYAMLTagsFromOptions(options)),
-			})
+			if !urlSchemeRe.MatchString(key) {
+				continue
+			}
+			parsed = append(parsed, parseYAMLURLMappedOptions(key, options, globalTags)...)
 		}
 		return parsed
 	default:
@@ -412,15 +412,37 @@ func parseYAMLURLEntry(entry any, globalTags []string) []taggedURL {
 			if !urlSchemeRe.MatchString(key) {
 				continue
 			}
-			parsed = append(parsed, taggedURL{
-				URL:  strings.TrimSpace(key),
-				Tags: mergeTags(globalTags, parseYAMLTagsFromOptions(options)),
-			})
+			parsed = append(parsed, parseYAMLURLMappedOptions(key, options, globalTags)...)
 		}
 		return parsed
 	default:
 		return nil
 	}
+}
+
+func parseYAMLURLMappedOptions(rawURL string, options any, globalTags []string) []taggedURL {
+	url := strings.TrimSpace(rawURL)
+	if entries, ok := options.([]any); ok {
+		parsed := []taggedURL{}
+		for _, entry := range entries {
+			entryMap, ok := asStringMap(entry)
+			if !ok {
+				continue
+			}
+			parsed = append(parsed, taggedURL{
+				URL:  url,
+				Tags: mergeTags(globalTags, parseYAMLTags(entryMap)),
+			})
+		}
+		if len(parsed) > 0 {
+			return parsed
+		}
+	}
+
+	return []taggedURL{{
+		URL:  url,
+		Tags: mergeTags(globalTags, parseYAMLTagsFromOptions(options)),
+	}}
 }
 
 func parseYAMLURLValue(value any, tags []string) []taggedURL {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,0 +1,504 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestLoadTaggedURLsSkipsMissingAndDirectoryPaths(t *testing.T) {
+	dir := t.TempDir()
+	configPath := writeConfig(t, "apprise.conf", "tag=json://localhost/one\n")
+
+	tagged := loadTaggedURLs([]string{
+		filepath.Join(dir, "missing.conf"),
+		dir,
+		configPath,
+	})
+
+	assertTaggedURLs(t, tagged, []taggedURL{{URL: "json://localhost/one", Tags: []string{"tag"}}})
+}
+
+func TestParseConfigFileTextFallbackForYAMLWithoutStructuredConfig(t *testing.T) {
+	configPath := writeConfig(t, "apprise.yaml", "tag=json://localhost/one\n")
+
+	tagged := parseConfigFile(configPath)
+
+	assertTaggedURLs(t, tagged, []taggedURL{{URL: "json://localhost/one", Tags: []string{"tag"}}})
+}
+
+func TestParseConfigFileMissingFile(t *testing.T) {
+	if tagged := parseConfigFile(filepath.Join(t.TempDir(), "missing.conf")); tagged != nil {
+		t.Fatalf("expected nil for missing file, got %#v", tagged)
+	}
+}
+
+func TestParseTextConfigCollectsURLsAndGroups(t *testing.T) {
+	cfg := parseTextConfig(`
+# ignored
+groupA, groupB = tagA, tagB
+tagA = json://localhost/one
+json://localhost/two
+`)
+
+	assertTaggedURLs(t, cfg.URLs, []taggedURL{
+		{URL: "json://localhost/one", Tags: []string{"taga"}},
+		{URL: "json://localhost/two"},
+	})
+	assertStringSlices(t, cfg.Groups["groupa"], []string{"taga", "tagb"})
+	assertStringSlices(t, cfg.Groups["groupb"], []string{"taga", "tagb"})
+}
+
+func TestParseTextConfigReturnsPartialConfigOnScannerError(t *testing.T) {
+	cfg := parseTextConfig("tag=json://localhost/one\n" + strings.Repeat("x", 70*1024))
+
+	assertTaggedURLs(t, cfg.URLs, []taggedURL{{URL: "json://localhost/one", Tags: []string{"tag"}}})
+}
+
+func TestParseYAMLConfigInvalidAndNonMappingInput(t *testing.T) {
+	for _, raw := range []string{"[", "- json://localhost/one"} {
+		cfg := parseYAMLConfig([]byte(raw))
+		if len(cfg.URLs) != 0 || len(cfg.Groups) != 0 {
+			t.Fatalf("expected empty config for %q, got %#v", raw, cfg)
+		}
+	}
+}
+
+func TestParseYAMLConfigSupportsURLShapesAndGlobalTags(t *testing.T) {
+	cfg := parseYAMLConfig([]byte(`
+tag: global, Team
+groups:
+  - groupA: tagA
+  - groupB:
+      - tagB
+urls:
+  - json://localhost/string
+  - url:
+      - json://localhost/list-one
+      - json://localhost/list-two
+    tag: tagA
+  - urls: json://localhost/urls-key
+    tags:
+      - tagB
+  - json://localhost/map-key:
+      - tag: tagC
+  - ignored: value
+`))
+
+	byURL := taggedByURL(cfg.URLs)
+	assertStringSlices(t, byURL["json://localhost/string"].Tags, []string{"global", "team"})
+	assertStringSlices(t, byURL["json://localhost/list-one"].Tags, []string{"global", "taga", "team"})
+	assertStringSlices(t, byURL["json://localhost/list-two"].Tags, []string{"global", "taga", "team"})
+	assertStringSlices(t, byURL["json://localhost/urls-key"].Tags, []string{"global", "tagb", "team"})
+	assertStringSlices(t, byURL["json://localhost/map-key"].Tags, []string{"global", "tagc", "team"})
+	if _, ok := byURL["ignored"]; ok {
+		t.Fatalf("unexpected non-url YAML entry parsed: %#v", byURL)
+	}
+	assertStringSlices(t, cfg.Groups["groupa"], []string{"taga"})
+	assertStringSlices(t, cfg.Groups["groupb"], []string{"tagb"})
+}
+
+func TestParseYAMLHelpersRejectUnsupportedURLShapes(t *testing.T) {
+	if urls := parseYAMLURLs(42, nil); urls != nil {
+		t.Fatalf("expected nil URLs for scalar url root, got %#v", urls)
+	}
+	if urls := parseYAMLURLEntry(42, nil); urls != nil {
+		t.Fatalf("expected nil URLs for scalar url entry, got %#v", urls)
+	}
+	if urls := parseYAMLURLValue(42, nil); urls != nil {
+		t.Fatalf("expected nil URLs for scalar url value, got %#v", urls)
+	}
+	if tags := parseYAMLTagsFromOptions(42); tags != nil {
+		t.Fatalf("expected nil tags for scalar options, got %#v", tags)
+	}
+	if tags := parseYAMLTagsFromOptions([]any{"invalid"}); len(tags) != 0 {
+		t.Fatalf("expected empty tags for non-map options list, got %#v", tags)
+	}
+}
+
+func TestParseYAMLConfigSupportsURLMap(t *testing.T) {
+	cfg := parseYAMLConfig([]byte(`
+urls:
+  json://localhost/one:
+    tag: tagA
+  json://localhost/two:
+    tags:
+      - tagB
+`))
+
+	byURL := taggedByURL(cfg.URLs)
+	assertStringSlices(t, byURL["json://localhost/one"].Tags, []string{"taga"})
+	assertStringSlices(t, byURL["json://localhost/two"].Tags, []string{"tagb"})
+}
+
+func TestParseYAMLGroupTagsCoversScalarListAndMapForms(t *testing.T) {
+	groups := parseYAMLGroups(mustYAMLValue(t, `
+group1: tagA, tagB
+group2:
+  - tagC
+  - tagD: comment
+group3:
+  tagE: comment
+group4: 4
+group5: true
+group6:
+`))
+
+	assertStringSlices(t, groups["group1"], []string{"taga", "tagb"})
+	assertStringSlices(t, groups["group2"], []string{"tagc", "tagd"})
+	assertStringSlices(t, groups["group3"], []string{"tage"})
+	assertStringSlices(t, groups["group4"], []string{"4"})
+	assertStringSlices(t, groups["group5"], []string{"true"})
+	if groups["group6"] != nil {
+		t.Fatalf("expected nil group6 tags, got %#v", groups["group6"])
+	}
+	assertStringSlices(t, parseYAMLGroupTags(struct{ Name string }{"tagZ"}), []string{"{tagz}"})
+}
+
+func TestParseYAMLGroupsIgnoresNonMapListEntries(t *testing.T) {
+	groups := parseYAMLGroups([]any{"invalid", map[string]any{"group": "tag"}})
+	assertStringSlices(t, groups["group"], []string{"tag"})
+}
+
+func TestParseYAMLTagValueCoversScalarsAndLists(t *testing.T) {
+	assertStringSlices(t, parseYAMLTagValue([]any{"tagA, tagB", 3, true, nil}), []string{"taga", "tagb", "3", "true"})
+	assertStringSlices(t, parseYAMLTagValue(map[string]any{"unexpected": true}), []string{"map[unexpected:true]"})
+}
+
+func TestResolveNotifyURLsFiltersTextGroupTags(t *testing.T) {
+	configPath := writeConfig(t, "apprise.conf", `
+mytagA,mytagB=json://localhost/a
+mygrouptag=mytagA
+`)
+
+	opts := &cliOptions{
+		configPaths: []string{configPath},
+		tags:        []string{"mygrouptag"},
+	}
+
+	tagged := resolveNotifyURLs(opts, nil, nil)
+	if len(tagged) != 1 {
+		t.Fatalf("expected one tagged URL, got %d: %#v", len(tagged), tagged)
+	}
+	if tagged[0].URL != "json://localhost/a" {
+		t.Fatalf("expected grouped URL, got %q", tagged[0].URL)
+	}
+}
+
+func TestResolveNotifyURLsFiltersYAMLGroupTags(t *testing.T) {
+	configPath := writeConfig(t, "apprise.yaml", `
+version: 1
+groups:
+  grouptag: mytag
+urls:
+  - json://localhost/one:
+      tag:
+        - mytag
+  - json://localhost/two:
+      tag: other
+`)
+
+	opts := &cliOptions{
+		configPaths: []string{configPath},
+		tags:        []string{"grouptag"},
+	}
+
+	tagged := resolveNotifyURLs(opts, nil, nil)
+	if len(tagged) != 1 {
+		t.Fatalf("expected one tagged URL, got %d: %#v", len(tagged), tagged)
+	}
+	if tagged[0].URL != "json://localhost/one" {
+		t.Fatalf("expected grouped YAML URL, got %q", tagged[0].URL)
+	}
+}
+
+func TestResolveNotifyURLsFiltersYAMLTagsAlias(t *testing.T) {
+	configPath := writeConfig(t, "apprise.yml", `
+version: 1
+urls:
+  - url: json://localhost/one
+    tags: mytag
+  - url: json://localhost/two
+    tag: other
+`)
+
+	opts := &cliOptions{
+		configPaths: []string{configPath},
+		tags:        []string{"mytag"},
+	}
+
+	tagged := resolveNotifyURLs(opts, nil, nil)
+	if len(tagged) != 1 {
+		t.Fatalf("expected one tagged URL, got %d: %#v", len(tagged), tagged)
+	}
+	if tagged[0].URL != "json://localhost/one" {
+		t.Fatalf("expected YAML tags alias URL, got %q", tagged[0].URL)
+	}
+}
+
+func TestResolveNotifyURLsUsesEnvURLsAndDefaultConfigPaths(t *testing.T) {
+	t.Setenv(defaultEnvAppriseURLs, "tag=json://localhost/env")
+	opts := &cliOptions{tags: []string{"tag"}}
+
+	tagged := resolveNotifyURLs(opts, nil, nil)
+
+	assertTaggedURLs(t, tagged, []taggedURL{{URL: "json://localhost/env", Tags: []string{"tag"}}})
+}
+
+func TestResolveNotifyURLsIgnoresTagsAndConfigWhenURLsProvided(t *testing.T) {
+	var stderr strings.Builder
+	opts := &cliOptions{
+		configPaths: []string{"ignored.conf"},
+		tags:        []string{"tag"},
+	}
+
+	tagged := resolveNotifyURLs(opts, []string{"json://localhost/one json://localhost/two"}, &stderr)
+
+	assertTaggedURLs(t, tagged, []taggedURL{
+		{URL: "json://localhost/one"},
+		{URL: "json://localhost/two"},
+	})
+	output := stderr.String()
+	if !strings.Contains(output, "--tag (-g) entries are ignored") {
+		t.Fatalf("expected tag warning, got %q", output)
+	}
+	if !strings.Contains(output, "Only the URLs will be referenced") {
+		t.Fatalf("expected config warning, got %q", output)
+	}
+}
+
+func TestResolveNotifyURLsUsesEnvURLTokens(t *testing.T) {
+	t.Setenv(defaultEnvAppriseURLs, "tag=bare-token")
+
+	tagged := resolveNotifyURLs(&cliOptions{tags: []string{"tag"}}, nil, nil)
+
+	assertTaggedURLs(t, tagged, []taggedURL{{URL: "bare-token", Tags: []string{"tag"}}})
+}
+
+func TestParseTaggedLinePreservesUntaggedURLQueryValues(t *testing.T) {
+	tagged := parseTaggedLine("json://localhost/path?format=full")
+	if len(tagged) != 1 {
+		t.Fatalf("expected one URL, got %d: %#v", len(tagged), tagged)
+	}
+	if tagged[0].URL != "json://localhost/path?format=full" {
+		t.Fatalf("expected full URL, got %q", tagged[0].URL)
+	}
+	if len(tagged[0].Tags) != 0 {
+		t.Fatalf("expected no tags, got %#v", tagged[0].Tags)
+	}
+}
+
+func TestParseTaggedLineHandlesMultipleURLsAndNoURL(t *testing.T) {
+	assertTaggedURLs(t, parseTaggedLine("tagA,tagB=json://localhost/one, xml://localhost/two"), []taggedURL{
+		{URL: "json://localhost/one", Tags: []string{"taga", "tagb"}},
+		{URL: "xml://localhost/two", Tags: []string{"taga", "tagb"}},
+	})
+	if tagged := parseTaggedLine("tagA="); tagged != nil {
+		t.Fatalf("expected nil when no URL is present, got %#v", tagged)
+	}
+}
+
+func TestParseGroupAssignmentValidation(t *testing.T) {
+	groups, tags, ok := parseGroupAssignment("groupA, groupB = tagA tagB")
+	if !ok {
+		t.Fatalf("expected valid group assignment")
+	}
+	assertStringSlices(t, groups, []string{"groupa", "groupb"})
+	assertStringSlices(t, tags, []string{"taga", "tagb"})
+
+	for _, line := range []string{"no equals", "=tag", "group=", "json://localhost/a=tag", "group=json://localhost/a"} {
+		if _, _, ok := parseGroupAssignment(line); ok {
+			t.Fatalf("expected invalid assignment for %q", line)
+		}
+	}
+	for _, line := range []string{" , = tag", "group = , ,"} {
+		if _, _, ok := parseGroupAssignment(line); ok {
+			t.Fatalf("expected empty parsed tags to be invalid for %q", line)
+		}
+	}
+}
+
+func TestDetectURLsCoversSchemeAndDelimitedForms(t *testing.T) {
+	assertStringSlices(t, detectURLs("json://localhost/one, xml://localhost/two,"), []string{"json://localhost/one", "xml://localhost/two"})
+	assertStringSlices(t, detectURLs("one two;three,[four]"), []string{"one", "two", "three", "four"})
+	assertStringSlices(t, detectURLs(" \t "), nil)
+}
+
+func TestParseTagsAndFilters(t *testing.T) {
+	assertStringSlices(t, parseTags(" TagA,tagB\t tagC ,, "), []string{"taga", "tagb", "tagc"})
+	assertStringSlices(t, parseTags(" , \t "), nil)
+	assertStringSlices(t, parseTags("\r"), nil)
+
+	filters := parseTagFilters([]string{" tagA, tagB ", "", "tagC"})
+	if !reflect.DeepEqual(filters, [][]string{{"taga", "tagb"}, {"tagc"}}) {
+		t.Fatalf("unexpected filters: %#v", filters)
+	}
+	if filters := parseTagFilters([]string{","}); len(filters) != 0 {
+		t.Fatalf("expected empty filters for delimiter-only value, got %#v", filters)
+	}
+	if filters := parseTagFilters(nil); filters != nil {
+		t.Fatalf("expected nil filters, got %#v", filters)
+	}
+}
+
+func TestFilterTaggedURLsAndMatchesTagFilters(t *testing.T) {
+	urls := []taggedURL{
+		{URL: "json://localhost/one", Tags: []string{"tagA", "tagB"}},
+		{URL: "json://localhost/two", Tags: []string{"tagC"}},
+		{URL: "json://localhost/untagged"},
+	}
+
+	assertTaggedURLs(t, filterTaggedURLs(urls, [][]string{{"taga", "tagb"}, {"missing"}}), []taggedURL{
+		{URL: "json://localhost/one", Tags: []string{"tagA", "tagB"}},
+	})
+	if got := filterTaggedURLs(urls, nil); !reflect.DeepEqual(got, urls) {
+		t.Fatalf("expected original URLs without filters, got %#v", got)
+	}
+	if !matchesTagFilters(nil, nil) {
+		t.Fatalf("expected empty filters to match")
+	}
+	if matchesTagFilters(nil, [][]string{{"tag"}}) {
+		t.Fatalf("expected tagged filter not to match untagged URL")
+	}
+	if !matchesTagFilters([]string{"anything"}, [][]string{{}, {"all"}}) {
+		t.Fatalf("expected all filter to match")
+	}
+	if matchesTagFilters([]string{"tagA"}, [][]string{{"tagA", "missing"}}) {
+		t.Fatalf("expected strict multi-tag filter not to match")
+	}
+}
+
+func TestApplyTagGroupsHandlesNestedSelfAndRecursiveGroups(t *testing.T) {
+	urls := []taggedURL{
+		{URL: "json://localhost/a", Tags: []string{"tagA"}},
+		{URL: "json://localhost/b", Tags: []string{"tagB"}},
+		{URL: "json://localhost/c", Tags: []string{"tagC"}},
+	}
+	groups := map[string][]string{
+		"groupa": {"tagA"},
+		"groupb": {"groupa", "tagB"},
+		"groupc": {"groupb"},
+		"empty":  nil,
+		"self":   {"self"},
+		"loopa":  {"loopb"},
+		"loopb":  {"loopa"},
+	}
+
+	tagged := applyTagGroups(urls, groups)
+
+	assertStringSlices(t, tagged[0].Tags, []string{"groupa", "groupb", "groupc", "taga"})
+	assertStringSlices(t, tagged[1].Tags, []string{"groupb", "groupc", "tagb"})
+	assertStringSlices(t, tagged[2].Tags, []string{"tagc"})
+}
+
+func TestApplyTagGroupsNoopsWithoutURLsOrGroups(t *testing.T) {
+	urls := []taggedURL{{URL: "json://localhost/one", Tags: []string{"tag"}}}
+	if got := applyTagGroups(nil, map[string][]string{"group": {"tag"}}); got != nil {
+		t.Fatalf("expected nil URLs, got %#v", got)
+	}
+	if got := applyTagGroups(urls, nil); !reflect.DeepEqual(got, urls) {
+		t.Fatalf("expected URLs unchanged, got %#v", got)
+	}
+	if got := sortedTagSet(nil); got != nil {
+		t.Fatalf("expected nil sorted tags, got %#v", got)
+	}
+	assertTaggedURLs(t, applyTagGroups([]taggedURL{{URL: "json://localhost/blank", Tags: []string{"", "tag"}}}, nil), []taggedURL{
+		{URL: "json://localhost/blank", Tags: []string{"", "tag"}},
+	})
+	assertTaggedURLs(t, applyTagGroups([]taggedURL{{URL: "json://localhost/blank", Tags: []string{"", "tag"}}}, map[string][]string{"group": {"tag"}}), []taggedURL{
+		{URL: "json://localhost/blank", Tags: []string{"group", "tag"}},
+	})
+	assertStringSlices(t, mergeTags([]string{"", "tag"}), []string{"tag"})
+}
+
+func TestYAMLPathAndPathResolutionHelpers(t *testing.T) {
+	for _, path := range []string{"apprise.yml", "apprise.yaml", "APPRISE.YAML"} {
+		if !isYAMLConfigPath(path) {
+			t.Fatalf("expected YAML path: %s", path)
+		}
+	}
+	if isYAMLConfigPath("apprise.conf") {
+		t.Fatalf("did not expect text config to be YAML")
+	}
+
+	t.Setenv("APPRISE_GO_TEST_DIR", "expanded")
+	assertStringSlices(t, splitPathList("a:b c;d,[e"), []string{"a:b", "c", "d", "e"})
+	assertStringSlices(t, expandPaths([]string{"", "$APPRISE_GO_TEST_DIR"}), []string{"expanded"})
+	if got := expandPath(""); got != "" {
+		t.Fatalf("expected empty path to stay empty, got %q", got)
+	}
+	if got := expandPath("~"); got == "~" || got == "" {
+		t.Fatalf("expected home expansion, got %q", got)
+	}
+	if got := expandPath("~/apprise-go-test"); !strings.HasSuffix(got, string(filepath.Separator)+"apprise-go-test") {
+		t.Fatalf("expected home-relative expansion, got %q", got)
+	}
+}
+
+func TestLoadConfigPathsPrecedence(t *testing.T) {
+	explicit := loadConfigPaths([]string{" explicit.conf "})
+	assertStringSlices(t, explicit, []string{"explicit.conf"})
+
+	t.Setenv(defaultEnvAppriseConfigPath, "one.conf two.conf")
+	assertStringSlices(t, loadConfigPaths(nil), []string{"one.conf", "two.conf"})
+
+	t.Setenv(defaultEnvAppriseConfigPath, "")
+	t.Setenv(defaultEnvAppriseConfigAlias, "alias.conf")
+	assertStringSlices(t, loadConfigPaths(nil), []string{"alias.conf"})
+
+	t.Setenv(defaultEnvAppriseConfigAlias, "")
+	defaults := loadConfigPaths(nil)
+	if len(defaults) == 0 {
+		t.Fatalf("expected default config paths")
+	}
+}
+
+func writeConfig(t *testing.T, name, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+func mustYAMLValue(t *testing.T, raw string) any {
+	t.Helper()
+	var value any
+	if err := yaml.Unmarshal([]byte(raw), &value); err != nil {
+		t.Fatalf("unmarshal YAML: %v", err)
+	}
+	return value
+}
+
+func taggedByURL(urls []taggedURL) map[string]taggedURL {
+	byURL := make(map[string]taggedURL, len(urls))
+	for _, entry := range urls {
+		byURL[entry.URL] = entry
+	}
+	return byURL
+}
+
+func assertTaggedURLs(t *testing.T, got []taggedURL, want []taggedURL) {
+	t.Helper()
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tagged URLs mismatch\ngot:  %#v\nwant: %#v", got, want)
+	}
+}
+
+func assertStringSlices(t *testing.T, got []string, want []string) {
+	t.Helper()
+	if len(want) == 0 {
+		if len(got) != 0 {
+			t.Fatalf("string slice mismatch\ngot:  %#v\nwant: %#v", got, want)
+		}
+		return
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("string slice mismatch\ngot:  %#v\nwant: %#v", got, want)
+	}
+}

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -115,14 +115,19 @@ func TestParseYAMLHelpersRejectUnsupportedURLShapes(t *testing.T) {
 	if tags := parseYAMLTagsFromOptions(42); tags != nil {
 		t.Fatalf("expected nil tags for scalar options, got %#v", tags)
 	}
+	assertStringSlices(t, parseYAMLTagsFromOptions([]any{map[string]any{"tag": "from-list"}, "invalid"}), []string{"from-list"})
 	if tags := parseYAMLTagsFromOptions([]any{"invalid"}); len(tags) != 0 {
 		t.Fatalf("expected empty tags for non-map options list, got %#v", tags)
 	}
+	assertTaggedURLs(t, parseYAMLURLMappedOptions("json://localhost/one", []any{"invalid"}, []string{"global"}), []taggedURL{
+		{URL: "json://localhost/one", Tags: []string{"global"}},
+	})
 }
 
 func TestParseYAMLConfigSupportsURLMap(t *testing.T) {
 	cfg := parseYAMLConfig([]byte(`
 urls:
+  ignored: value
   json://localhost/one:
     tag: tagA
   json://localhost/two:
@@ -133,6 +138,36 @@ urls:
 	byURL := taggedByURL(cfg.URLs)
 	assertStringSlices(t, byURL["json://localhost/one"].Tags, []string{"taga"})
 	assertStringSlices(t, byURL["json://localhost/two"].Tags, []string{"tagb"})
+}
+
+func TestParseYAMLConfigMatchesAppriseTagsAliasListExpansion(t *testing.T) {
+	cfg := parseYAMLConfig([]byte(`
+urls:
+  - json://localhost/one:
+    - tags: test1
+    - tags: test2
+  - json://localhost/two:
+    - tags: test3
+`))
+
+	assertTaggedURLs(t, cfg.URLs, []taggedURL{
+		{URL: "json://localhost/one", Tags: []string{"test1"}},
+		{URL: "json://localhost/one", Tags: []string{"test2"}},
+		{URL: "json://localhost/two", Tags: []string{"test3"}},
+	})
+}
+
+func TestParseYAMLConfigMatchesAppriseTagPriorityOverTags(t *testing.T) {
+	cfg := parseYAMLConfig([]byte(`
+urls:
+  - json://localhost/one:
+      tag: primary
+      tags: secondary
+`))
+
+	assertTaggedURLs(t, cfg.URLs, []taggedURL{
+		{URL: "json://localhost/one", Tags: []string{"primary"}},
+	})
 }
 
 func TestParseYAMLGroupTagsCoversScalarListAndMapForms(t *testing.T) {
@@ -189,6 +224,34 @@ mygrouptag=mytagA
 	}
 }
 
+func TestResolveNotifyURLsMatchesIssue47TextTagAndGroupRepro(t *testing.T) {
+	configPath := writeConfig(t, "apprise.conf", `
+mytagA,mytagB=tgram://123456:abcdef/7890/
+mygrouptag=mytagA
+`)
+
+	for _, tc := range []struct {
+		name string
+		tag  string
+	}{
+		{name: "single tag works", tag: "mytagB"},
+		{name: "group tag works", tag: "mygrouptag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &cliOptions{
+				configPaths: []string{configPath},
+				tags:        []string{tc.tag},
+			}
+
+			tagged := resolveNotifyURLs(opts, nil, nil)
+
+			assertTaggedURLs(t, tagged, []taggedURL{
+				{URL: "tgram://123456:abcdef/7890/", Tags: []string{"mygrouptag", "mytaga", "mytagb"}},
+			})
+		})
+	}
+}
+
 func TestResolveNotifyURLsFiltersYAMLGroupTags(t *testing.T) {
 	configPath := writeConfig(t, "apprise.yaml", `
 version: 1
@@ -213,6 +276,39 @@ urls:
 	}
 	if tagged[0].URL != "json://localhost/one" {
 		t.Fatalf("expected grouped YAML URL, got %q", tagged[0].URL)
+	}
+}
+
+func TestResolveNotifyURLsMatchesIssue47YAMLTagAndGroupRepro(t *testing.T) {
+	configPath := writeConfig(t, "apprise.yaml", `
+version: 1
+groups:
+  grouptag: mytag
+urls:
+  - tgram://123456:abcdef/7890/:
+      tag:
+        - mytag
+`)
+
+	for _, tc := range []struct {
+		name string
+		tag  string
+	}{
+		{name: "yaml tag works", tag: "mytag"},
+		{name: "yaml group tag works", tag: "grouptag"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			opts := &cliOptions{
+				configPaths: []string{configPath},
+				tags:        []string{tc.tag},
+			}
+
+			tagged := resolveNotifyURLs(opts, nil, nil)
+
+			assertTaggedURLs(t, tagged, []taggedURL{
+				{URL: "tgram://123456:abcdef/7890/", Tags: []string{"grouptag", "mytag"}},
+			})
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes config-driven tag filtering so CLI sends using `--config` plus `--tag` can resolve URLs tagged through text or YAML tag groups.

## What changed

- Parse config files into URL and tag-group structures instead of only scanning simple URL lines.
- Add YAML config parsing for `urls`, `url`/`urls`, `tag`/`tags`, global tags, and `groups` shapes.
- Recursively normalize tag groups and apply matching group names to URL tag sets before filtering.
- Expand YAML list-of-dicts URL options into separate URL entries to match Python Apprise behavior.
- Preserve untagged URLs containing `=` query parameters.
- Add full config-layer tests covering text configs, YAML variants, recursive/self-referential groups, tag filters, env/path helpers, malformed inputs, and coverage edge cases.

## Root cause

The Go port had provider request parity coverage, but not config-layer parity. Text group aliases such as `grouptag=mytag` were discarded because they had no URL, and YAML configs were not parsed structurally, so `--config file --tag grouptag` could resolve no notification URLs.

## Issue #47 coverage

Adds explicit regression coverage for Patrick Khoo's repro:

```text
mytagA,mytagB=tgram://123456:abcdef/7890/
mygrouptag=mytagA
```

The tests assert both of these resolve the same configured `tgram://` URL:

- `--config apprise.conf -g mytagB -b "test"`
- `--config apprise.conf -g mygrouptag -b "test"`

There is also matching YAML `tgram://` coverage for direct tags and group tags.

## Apprise parity coverage added

- YAML `tags` alias in dict form.
- YAML `tags` alias in list-of-dicts form, expanding one entry per list item.
- `tag` priority over `tags` when both are present.
- Text and YAML recursive, empty, self-referential, and cyclic tag groups.

## Validation

- `go test ./internal/cli -coverprofile=/tmp/apprise-go-cli.cover`
- `go tool cover -func=/tmp/apprise-go-cli.cover | rg 'config.go|total:'`
- `go test ./...`

`internal/cli/config.go` reports 100% function coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config files support YAML (.yaml/.yml) plus improved text parsing
  * Tag-group definitions with recursive expansion applied to URL entries

* **Chores**
  * Added YAML parsing dependency

* **Tests**
  * Comprehensive unit tests for config parsing, tag/group resolution, YAML/text formats, path/env handling and precedence

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/apprise-go/pull/49?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->