### PR TITLE
fix: honor CLI input format for formatted notifications

### DIFF
--- a/.codex/coderabbit-fixes-wip.md
+++ b/.codex/coderabbit-fixes-wip.md
@@ -1,0 +1,63 @@
+# CodeRabbit Fixes WIP
+
+## Context
+
+- Repo: unraid/apprise-go
+- Branch: codex/fix-format-input-handling
+- PR: #50
+- PR URL: https://github.com/unraid/apprise-go/pull/50
+- Generated at: 2026-05-18T16:22:30Z
+
+## Inputs Pulled
+
+- [x] Unresolved CodeRabbit review threads pulled
+- [x] Top-level CodeRabbit review notes pulled
+- [x] Top-level actionable review-body comments extracted into queue
+
+## Fix Queue
+
+| Item ID | Type | File | Line | Summary | Status | Link | Evidence |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| CR-001 | thread | internal/notify/format_convert.go | 102 | HTML to Markdown currently uses HTML to text. Verified current code does this, but upstream Python Apprise has the same contract in conversion.py. | BLOCKED | https://github.com/unraid/apprise-go/pull/50#discussion_r3260222516 | Skipped to preserve Python parity. |
+| CR-002 | thread | internal/cli/cli_test.go | 154 | Convert added CLI Run Telegram/mailto tests from Go-only assertions to Python-vs-Go parity. | DONE | https://github.com/unraid/apprise-go/pull/50#discussion_r3260277570 | `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil` passed. |
+| CR-003 | thread | internal/notify/mailto_format_test.go | 31 | Use `net.JoinHostPort` when building mailto test authority. | DONE | https://github.com/unraid/apprise-go/pull/50#discussion_r3260357765 | `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil` passed. |
+| CR-004 | thread | internal/testutil/request_compare.go | 50 | Use `strings.EqualFold` for method comparison. | DONE | https://github.com/unraid/apprise-go/pull/50#discussion_r3260357786 | `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil` passed. |
+| RVW-001 | review-body | top-level | n/a | Earlier review body with six inline comments. | DONE | https://github.com/unraid/apprise-go/pull/50#pullrequestreview-4311662350 | Covered by prior commits plus CR-001 skip reason. |
+| RVW-002 | review-body | top-level | n/a | Review body requested Python parity for CLI Run Telegram/mailto format tests. | DONE | https://github.com/unraid/apprise-go/pull/50#pullrequestreview-4311723839 | Covered by CR-002. |
+| RVW-003 | review-body | internal/notify/telegram_format_test.go | 34-55 | Add Python parity to MarkdownV2 title escaping test. | BLOCKED | https://github.com/unraid/apprise-go/pull/50#pullrequestreview-4311819314 | Skipped: Python Apprise MarkdownV2 title/body blending differs from the Go-side hardening test, so adding this assertion would fail for an implementation-contract mismatch rather than guarding the reserved-character escaper. |
+| RVW-004 | review-body | internal/notify/mailto_format_test.go | 31 | Latest review-body mailto IPv6-safe authority item. | DONE | https://github.com/unraid/apprise-go/pull/50#pullrequestreview-4311819314 | Covered by CR-003. |
+| RVW-005 | review-body | internal/testutil/request_compare.go | 49-50 | Latest review-body `strings.EqualFold` item. | DONE | https://github.com/unraid/apprise-go/pull/50#pullrequestreview-4311819314 | Covered by CR-004. |
+
+## Execution Log
+
+### 1. Item: CR-002
+- Action: Replaced Go-only CLI Telegram HTTP assertions with `assertRunHTTPRequestParity`, using Python request capture and Go `Run(...)` under `CaptureGoRequests`. Replaced the mailto CLI test with Python CLI send plus Go `Run(...)` against the shared SMTP capture, comparing normalized SMTP output.
+- Validation: `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil`
+- Result: DONE
+
+### 2. Item: CR-003
+- Action: Changed mailto format test URL construction to use `net.JoinHostPort(host, port)`.
+- Validation: `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil`
+- Result: DONE
+
+### 3. Item: CR-004
+- Action: Replaced `strings.ToUpper(...) != strings.ToUpper(...)` with `!strings.EqualFold(...)`.
+- Validation: `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil`
+- Result: DONE
+
+### 4. Item: CR-001
+- Action: Verified against `../apprise/apprise/apprise/conversion.py`; Python Apprise currently maps HTML to Markdown through `html_to_text`.
+- Validation: Code inspection.
+- Result: BLOCKED; skipped to preserve parity.
+
+### 5. Item: RVW-003
+- Action: Verified the request would compare Go MarkdownV2 title escaping against Python's different Markdown title/body blending behavior.
+- Validation: Code inspection of `../apprise/apprise/apprise/plugins/base.py` and `../apprise/apprise/apprise/plugins/telegram.py`.
+- Result: BLOCKED; skipped as not a valid parity assertion against current upstream behavior.
+
+## Final Checks
+
+- [ ] Queue reviewed: no `TODO` left
+- [x] Remaining `BLOCKED` items documented with reason
+- [ ] Re-pulled CodeRabbit threads and reviews
+- [ ] No unhandled top-level review-body comment remains

--- a/.codex/coderabbit-fixes-wip.md
+++ b/.codex/coderabbit-fixes-wip.md
@@ -57,7 +57,9 @@
 
 ## Final Checks
 
-- [ ] Queue reviewed: no `TODO` left
+- [x] Queue reviewed: no `TODO` left
 - [x] Remaining `BLOCKED` items documented with reason
-- [ ] Re-pulled CodeRabbit threads and reviews
-- [ ] No unhandled top-level review-body comment remains
+- [x] Re-pulled CodeRabbit threads and reviews
+- [x] No unhandled top-level review-body comment remains
+
+Re-pull result: one unresolved CodeRabbit inline thread remains (`CR-001`) and is intentionally `BLOCKED` because the requested HTML to Markdown change conflicts with current upstream Python Apprise conversion behavior. The remaining top-level review-body entries are duplicates or aggregates mapped to queue items above.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -194,7 +194,6 @@ func Run(args []string, stdout, stderr io.Writer) int {
 	}
 
 	// TODO: Wire these options into CLI behavior once the runtime supports them.
-	_ = opts.inputFormat
 	_ = opts.disableAsync
 	_ = opts.attachments
 	_ = opts.pluginPaths
@@ -220,6 +219,13 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		}
 
 		scheme := strings.ToLower(parsed.Scheme)
+		sendBody, err := notify.ConvertMessageFormat(body, opts.inputFormat, parsed.Query["format"])
+		if err != nil {
+			fmt.Fprintln(stderr, err)
+			failed = true
+			continue
+		}
+		body := sendBody
 		switch scheme {
 		case "apprise", "apprises":
 			appriseTarget, err := notify.NewAppriseTarget(parsed)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -109,7 +109,6 @@ func TestRunConvertsMarkdownInputForMailtoHTMLTarget(t *testing.T) {
 	if len(pythonMessages) == 0 {
 		t.Fatalf("no smtp message captured from python")
 	}
-	pythonMessage := pythonMessages[len(pythonMessages)-1]
 
 	capture.Reset()
 
@@ -124,10 +123,9 @@ func TestRunConvertsMarkdownInputForMailtoHTMLTarget(t *testing.T) {
 	if len(goMessages) == 0 {
 		t.Fatalf("no smtp message captured from go")
 	}
-	goMessage := goMessages[len(goMessages)-1]
 
-	testutil.AssertSMTPMessagesMatch(t, pythonMessage, goMessage)
-	normalized := testutil.NormalizeSMTPMessage(t, goMessage)
+	testutil.AssertSMTPMessageSequencesMatch(t, pythonMessages, goMessages)
+	normalized := testutil.NormalizeSMTPMessage(t, goMessages[0])
 	if !strings.Contains(normalized.Body, "<em>This is Italics Text</em>") {
 		t.Fatalf("expected converted markdown in email body, got %s", normalized.Body)
 	}
@@ -162,7 +160,7 @@ func readRequestSpecs(t *testing.T, requests <-chan notify.RequestSpec) []notify
 		select {
 		case spec := <-requests:
 			specs = append(specs, spec)
-		case <-time.After(50 * time.Millisecond):
+		case <-time.After(time.Second):
 			if len(specs) == 0 {
 				t.Fatalf("timed out waiting for request")
 			}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -12,6 +12,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/unraid/apprise-go/internal/notify"
+	"github.com/unraid/apprise-go/internal/testutil"
 )
 
 func TestRunNoArgsDoesNotReadStdin(t *testing.T) {
@@ -51,41 +54,34 @@ func TestRunNoArgsDoesNotReadStdin(t *testing.T) {
 }
 
 func TestRunConvertsMarkdownInputForHTMLTargetFormat(t *testing.T) {
-	requests := make(chan map[string]any, 1)
+	testutil.RequirePythonApprise(t)
+
+	requests := make(chan notify.RequestSpec, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer r.Body.Close()
-		var payload map[string]any
-		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-			t.Errorf("decode request: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		requests <- payload
+		requests <- captureRequestSpec(t, r)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
 	targetURL := "json://" + server.Listener.Addr().String() + "/notify?format=html"
+	body := "_This is Italics Text_"
+
+	pyStdout, pyStderr, err := testutil.RunApprise(t, "-i", "markdown", "-b", body, targetURL)
+	if err != nil {
+		t.Fatalf("python apprise failed: %v stdout=%s stderr=%s", err, pyStdout, pyStderr)
+	}
+	pythonRequests := readRequestSpecs(t, requests)
+
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	code := Run([]string{"-i", "markdown", "-b", "_This is Italics Text_", targetURL}, stdout, stderr)
+	code := Run([]string{"-i", "markdown", "-b", body, targetURL}, stdout, stderr)
 	if code != 0 {
 		t.Fatalf("expected success, got code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
+	goRequests := readRequestSpecs(t, requests)
 
-	select {
-	case payload := <-requests:
-		message, ok := payload["message"].(string)
-		if !ok {
-			t.Fatalf("missing message payload: %#v", payload)
-		}
-		if !strings.Contains(message, "<em>This is Italics Text</em>") {
-			t.Fatalf("expected markdown converted to HTML, got %q", message)
-		}
-	case <-time.After(time.Second):
-		t.Fatalf("timed out waiting for request")
-	}
+	testutil.AssertRequestSpecSequenceMatches(t, pythonRequests, goRequests)
 }
 
 func TestRunSendsHTMLInputToTelegramHTMLTarget(t *testing.T) {
@@ -154,6 +150,44 @@ func TestRunConvertsMarkdownInputForMailtoHTMLTarget(t *testing.T) {
 	}
 	if !strings.Contains(message, "<em>This is Italics Text</em>") {
 		t.Fatalf("expected converted markdown in email body, got %s", message)
+	}
+}
+
+func captureRequestSpec(t *testing.T, r *http.Request) notify.RequestSpec {
+	t.Helper()
+	defer r.Body.Close()
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	headers := map[string]string{}
+	for key, values := range r.Header {
+		headers[key] = strings.Join(values, ",")
+	}
+
+	return notify.RequestSpec{
+		Method:  r.Method,
+		URL:     "http://" + r.Host + r.URL.RequestURI(),
+		Headers: headers,
+		Body:    string(body),
+	}
+}
+
+func readRequestSpecs(t *testing.T, requests <-chan notify.RequestSpec) []notify.RequestSpec {
+	t.Helper()
+
+	specs := []notify.RequestSpec{}
+	for {
+		select {
+		case spec := <-requests:
+			specs = append(specs, spec)
+		case <-time.After(50 * time.Millisecond):
+			if len(specs) == 0 {
+				t.Fatalf("timed out waiting for request")
+			}
+			return specs
+		}
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,11 +1,9 @@
 package cli
 
 import (
-	"bufio"
 	"bytes"
-	"encoding/json"
+	"fmt"
 	"io"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -85,71 +83,53 @@ func TestRunConvertsMarkdownInputForHTMLTargetFormat(t *testing.T) {
 }
 
 func TestRunSendsHTMLInputToTelegramHTMLTarget(t *testing.T) {
-	payloads := captureHTTPPayloads(t)
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
-	code := Run([]string{
-		"-i", "html",
-		"-b", "<b>This is Bold Text</b>",
-		"tgram://123456:abcdef/7890/?format=html",
-	}, stdout, stderr)
-	if code != 0 {
-		t.Fatalf("expected success, got code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
-	}
-
-	payload := readPayload(t, payloads)
-	if payload["parse_mode"] != "HTML" {
-		t.Fatalf("expected HTML parse mode, got %#v", payload["parse_mode"])
-	}
-	if payload["text"] != "<b>This is Bold Text</b>" {
-		t.Fatalf("expected unescaped HTML body, got %#v", payload["text"])
-	}
+	assertRunHTTPRequestParity(t, "tgram://123456:abcdef/7890/?format=html", "<b>This is Bold Text</b>", "", "html")
 }
 
 func TestRunSendsMarkdownInputToTelegramMarkdownTarget(t *testing.T) {
-	payloads := captureHTTPPayloads(t)
-	stdout := &bytes.Buffer{}
-	stderr := &bytes.Buffer{}
-
-	code := Run([]string{
-		"-i", "markdown",
-		"-b", "_This is Italics Text_",
-		"tgram://123456:abcdef/7890/?format=markdown&mdv=v1",
-	}, stdout, stderr)
-	if code != 0 {
-		t.Fatalf("expected success, got code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
-	}
-
-	payload := readPayload(t, payloads)
-	if payload["parse_mode"] != "Markdown" {
-		t.Fatalf("expected Markdown parse mode, got %#v", payload["parse_mode"])
-	}
-	if payload["text"] != "_This is Italics Text_" {
-		t.Fatalf("expected markdown body, got %#v", payload["text"])
-	}
+	assertRunHTTPRequestParity(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v1", "_This is Italics Text_", "", "markdown")
 }
 
 func TestRunConvertsMarkdownInputForMailtoHTMLTarget(t *testing.T) {
-	messages := startSMTPServer(t)
+	testutil.RequirePythonApprise(t)
+
+	capture := testutil.StartSMTPCapture(t)
+	defer func() {
+		_ = capture.Close()
+	}()
+
+	rawURL := "mailto://" + capture.Addr() + "/recipient@example.com?from=sender@example.com&format=html&mode=insecure"
+	body := "_This is Italics Text_"
+
+	pyStdout, pyStderr, err := testutil.RunApprise(t, "-i", "markdown", "-b", body, rawURL)
+	if err != nil {
+		t.Fatalf("python apprise failed: %v stdout=%s stderr=%s", err, pyStdout, pyStderr)
+	}
+	pythonMessages := capture.Messages()
+	if len(pythonMessages) == 0 {
+		t.Fatalf("no smtp message captured from python")
+	}
+	pythonMessage := pythonMessages[len(pythonMessages)-1]
+
+	capture.Reset()
+
 	stdout := &bytes.Buffer{}
 	stderr := &bytes.Buffer{}
 
-	code := Run([]string{
-		"-i", "markdown",
-		"-b", "_This is Italics Text_",
-		"mailto://" + messages.addr + "/recipient@example.com?from=sender@example.com&format=html&mode=insecure",
-	}, stdout, stderr)
+	code := Run([]string{"-i", "markdown", "-b", body, rawURL}, stdout, stderr)
 	if code != 0 {
 		t.Fatalf("expected success, got code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
 	}
-
-	message := messages.read(t)
-	if !strings.Contains(message, "Content-Type: text/html") {
-		t.Fatalf("expected html email, got %s", message)
+	goMessages := capture.Messages()
+	if len(goMessages) == 0 {
+		t.Fatalf("no smtp message captured from go")
 	}
-	if !strings.Contains(message, "<em>This is Italics Text</em>") {
-		t.Fatalf("expected converted markdown in email body, got %s", message)
+	goMessage := goMessages[len(goMessages)-1]
+
+	testutil.AssertSMTPMessagesMatch(t, pythonMessage, goMessage)
+	normalized := testutil.NormalizeSMTPMessage(t, goMessage)
+	if !strings.Contains(normalized.Body, "<em>This is Italics Text</em>") {
+		t.Fatalf("expected converted markdown in email body, got %s", normalized.Body)
 	}
 }
 
@@ -191,138 +171,27 @@ func readRequestSpecs(t *testing.T, requests <-chan notify.RequestSpec) []notify
 	}
 }
 
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
-func captureHTTPPayloads(t *testing.T) <-chan map[string]any {
+func assertRunHTTPRequestParity(t *testing.T, rawURL, body, title, inputFormat string) {
 	t.Helper()
-	payloads := make(chan map[string]any, 1)
-	oldClient := http.DefaultClient
-	http.DefaultClient = &http.Client{
-		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
-			defer req.Body.Close()
-			var payload map[string]any
-			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
-				t.Errorf("decode request: %v", err)
-			}
-			payloads <- payload
-			return &http.Response{
-				StatusCode: http.StatusOK,
-				Body:       io.NopCloser(strings.NewReader("{}")),
-				Header:     make(http.Header),
-				Request:    req,
-			}, nil
-		}),
-	}
-	t.Cleanup(func() {
-		http.DefaultClient = oldClient
-	})
-	return payloads
-}
+	testutil.RequirePythonApprise(t)
 
-func readPayload(t *testing.T, payloads <-chan map[string]any) map[string]any {
-	t.Helper()
-	select {
-	case payload := <-payloads:
-		return payload
-	case <-time.After(time.Second):
-		t.Fatalf("timed out waiting for request")
+	pythonSpecs := testutil.CapturePythonRequestsWithFormat(t, rawURL, body, title, inputFormat)
+
+	goSpecs := testutil.CaptureGoRequests(t, func() error {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		args := []string{"-i", inputFormat, "-b", body}
+		if title != "" {
+			args = append(args, "-t", title)
+		}
+		args = append(args, rawURL)
+
+		code := Run(args, stdout, stderr)
+		if code != 0 {
+			return fmt.Errorf("Run failed with code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		}
 		return nil
-	}
-}
-
-type smtpMessages struct {
-	addr string
-	ch   <-chan string
-}
-
-func startSMTPServer(t *testing.T) smtpMessages {
-	t.Helper()
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("listen smtp: %v", err)
-	}
-	messages := make(chan string, 1)
-	done := make(chan struct{})
-	t.Cleanup(func() {
-		_ = listener.Close()
-		<-done
 	})
 
-	go func() {
-		defer close(done)
-		conn, err := listener.Accept()
-		if err != nil {
-			return
-		}
-		defer conn.Close()
-
-		reader := bufio.NewReader(conn)
-		writer := bufio.NewWriter(conn)
-		writeSMTPLine(t, writer, "220 localhost ESMTP")
-		for {
-			line, err := reader.ReadString('\n')
-			if err != nil {
-				return
-			}
-			command := strings.ToUpper(strings.TrimSpace(line))
-			switch {
-			case strings.HasPrefix(command, "EHLO"), strings.HasPrefix(command, "HELO"):
-				writeSMTPLine(t, writer, "250-localhost")
-				writeSMTPLine(t, writer, "250 OK")
-			case strings.HasPrefix(command, "MAIL FROM:"), strings.HasPrefix(command, "RCPT TO:"):
-				writeSMTPLine(t, writer, "250 OK")
-			case command == "DATA":
-				writeSMTPLine(t, writer, "354 End data with <CR><LF>.<CR><LF>")
-				var data strings.Builder
-				for {
-					line, err := reader.ReadString('\n')
-					if err != nil {
-						return
-					}
-					if strings.TrimSpace(line) == "." {
-						break
-					}
-					data.WriteString(line)
-				}
-				messages <- data.String()
-				writeSMTPLine(t, writer, "250 OK")
-			case command == "QUIT":
-				writeSMTPLine(t, writer, "221 Bye")
-				return
-			default:
-				writeSMTPLine(t, writer, "250 OK")
-			}
-		}
-	}()
-
-	return smtpMessages{
-		addr: listener.Addr().String(),
-		ch:   messages,
-	}
-}
-
-func (s smtpMessages) read(t *testing.T) string {
-	t.Helper()
-	select {
-	case message := <-s.ch:
-		return message
-	case <-time.After(time.Second):
-		t.Fatalf("timed out waiting for smtp message")
-		return ""
-	}
-}
-
-func writeSMTPLine(t *testing.T, writer *bufio.Writer, line string) {
-	t.Helper()
-	if _, err := writer.WriteString(line + "\r\n"); err != nil {
-		t.Errorf("write smtp response: %v", err)
-		return
-	}
-	if err := writer.Flush(); err != nil {
-		t.Errorf("flush smtp response: %v", err)
-	}
+	testutil.AssertRequestSpecSequenceMatches(t, pythonSpecs, goSpecs)
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,8 +1,11 @@
 package cli
 
 import (
+	"bufio"
 	"bytes"
 	"encoding/json"
+	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -82,5 +85,210 @@ func TestRunConvertsMarkdownInputForHTMLTargetFormat(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatalf("timed out waiting for request")
+	}
+}
+
+func TestRunSendsHTMLInputToTelegramHTMLTarget(t *testing.T) {
+	payloads := captureHTTPPayloads(t)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := Run([]string{
+		"-i", "html",
+		"-b", "<b>This is Bold Text</b>",
+		"tgram://123456:abcdef/7890/?format=html",
+	}, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("expected success, got code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	payload := readPayload(t, payloads)
+	if payload["parse_mode"] != "HTML" {
+		t.Fatalf("expected HTML parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "<b>This is Bold Text</b>" {
+		t.Fatalf("expected unescaped HTML body, got %#v", payload["text"])
+	}
+}
+
+func TestRunSendsMarkdownInputToTelegramMarkdownTarget(t *testing.T) {
+	payloads := captureHTTPPayloads(t)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := Run([]string{
+		"-i", "markdown",
+		"-b", "_This is Italics Text_",
+		"tgram://123456:abcdef/7890/?format=markdown&mdv=v1",
+	}, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("expected success, got code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	payload := readPayload(t, payloads)
+	if payload["parse_mode"] != "Markdown" {
+		t.Fatalf("expected Markdown parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "_This is Italics Text_" {
+		t.Fatalf("expected markdown body, got %#v", payload["text"])
+	}
+}
+
+func TestRunConvertsMarkdownInputForMailtoHTMLTarget(t *testing.T) {
+	messages := startSMTPServer(t)
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := Run([]string{
+		"-i", "markdown",
+		"-b", "_This is Italics Text_",
+		"mailto://" + messages.addr + "/recipient@example.com?from=sender@example.com&format=html&mode=insecure",
+	}, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("expected success, got code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	message := messages.read(t)
+	if !strings.Contains(message, "Content-Type: text/html") {
+		t.Fatalf("expected html email, got %s", message)
+	}
+	if !strings.Contains(message, "<em>This is Italics Text</em>") {
+		t.Fatalf("expected converted markdown in email body, got %s", message)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func captureHTTPPayloads(t *testing.T) <-chan map[string]any {
+	t.Helper()
+	payloads := make(chan map[string]any, 1)
+	oldClient := http.DefaultClient
+	http.DefaultClient = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			defer req.Body.Close()
+			var payload map[string]any
+			if err := json.NewDecoder(req.Body).Decode(&payload); err != nil {
+				t.Errorf("decode request: %v", err)
+			}
+			payloads <- payload
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader("{}")),
+				Header:     make(http.Header),
+				Request:    req,
+			}, nil
+		}),
+	}
+	t.Cleanup(func() {
+		http.DefaultClient = oldClient
+	})
+	return payloads
+}
+
+func readPayload(t *testing.T, payloads <-chan map[string]any) map[string]any {
+	t.Helper()
+	select {
+	case payload := <-payloads:
+		return payload
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for request")
+		return nil
+	}
+}
+
+type smtpMessages struct {
+	addr string
+	ch   <-chan string
+}
+
+func startSMTPServer(t *testing.T) smtpMessages {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen smtp: %v", err)
+	}
+	messages := make(chan string, 1)
+	done := make(chan struct{})
+	t.Cleanup(func() {
+		_ = listener.Close()
+		<-done
+	})
+
+	go func() {
+		defer close(done)
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		reader := bufio.NewReader(conn)
+		writer := bufio.NewWriter(conn)
+		writeSMTPLine(t, writer, "220 localhost ESMTP")
+		for {
+			line, err := reader.ReadString('\n')
+			if err != nil {
+				return
+			}
+			command := strings.ToUpper(strings.TrimSpace(line))
+			switch {
+			case strings.HasPrefix(command, "EHLO"), strings.HasPrefix(command, "HELO"):
+				writeSMTPLine(t, writer, "250-localhost")
+				writeSMTPLine(t, writer, "250 OK")
+			case strings.HasPrefix(command, "MAIL FROM:"), strings.HasPrefix(command, "RCPT TO:"):
+				writeSMTPLine(t, writer, "250 OK")
+			case command == "DATA":
+				writeSMTPLine(t, writer, "354 End data with <CR><LF>.<CR><LF>")
+				var data strings.Builder
+				for {
+					line, err := reader.ReadString('\n')
+					if err != nil {
+						return
+					}
+					if strings.TrimSpace(line) == "." {
+						break
+					}
+					data.WriteString(line)
+				}
+				messages <- data.String()
+				writeSMTPLine(t, writer, "250 OK")
+			case command == "QUIT":
+				writeSMTPLine(t, writer, "221 Bye")
+				return
+			default:
+				writeSMTPLine(t, writer, "250 OK")
+			}
+		}
+	}()
+
+	return smtpMessages{
+		addr: listener.Addr().String(),
+		ch:   messages,
+	}
+}
+
+func (s smtpMessages) read(t *testing.T) string {
+	t.Helper()
+	select {
+	case message := <-s.ch:
+		return message
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for smtp message")
+		return ""
+	}
+}
+
+func writeSMTPLine(t *testing.T, writer *bufio.Writer, line string) {
+	t.Helper()
+	if _, err := writer.WriteString(line + "\r\n"); err != nil {
+		t.Errorf("write smtp response: %v", err)
+		return
+	}
+	if err := writer.Flush(); err != nil {
+		t.Errorf("flush smtp response: %v", err)
 	}
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,7 +2,11 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -40,5 +44,43 @@ func TestRunNoArgsDoesNotReadStdin(t *testing.T) {
 		case <-time.After(500 * time.Millisecond):
 			t.Fatalf("Run blocked on stdin after closing pipe")
 		}
+	}
+}
+
+func TestRunConvertsMarkdownInputForHTMLTargetFormat(t *testing.T) {
+	requests := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Errorf("decode request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		requests <- payload
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	targetURL := "json://" + server.Listener.Addr().String() + "/notify?format=html"
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+
+	code := Run([]string{"-i", "markdown", "-b", "_This is Italics Text_", targetURL}, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("expected success, got code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+
+	select {
+	case payload := <-requests:
+		message, ok := payload["message"].(string)
+		if !ok {
+			t.Fatalf("missing message payload: %#v", payload)
+		}
+		if !strings.Contains(message, "<em>This is Italics Text</em>") {
+			t.Fatalf("expected markdown converted to HTML, got %q", message)
+		}
+	case <-time.After(time.Second):
+		t.Fatalf("timed out waiting for request")
 	}
 }

--- a/internal/notify/format_convert.go
+++ b/internal/notify/format_convert.go
@@ -1,6 +1,7 @@
 package notify
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -66,6 +67,55 @@ func markdownToHTML(content string) string {
 		Flags: html.CommonFlags,
 	})
 	return string(markdown.ToHTML([]byte(content), mdParser, renderer))
+}
+
+func ConvertMessageFormat(content, inputFormat, outputFormat string) (string, error) {
+	input := normalizeNotifyFormat(inputFormat)
+	output := normalizeNotifyFormat(outputFormat)
+	if input == "" {
+		input = "text"
+	}
+	if output == "" {
+		return content, nil
+	}
+	if !isSupportedNotifyFormat(input) {
+		return "", fmt.Errorf("invalid input format: %s", inputFormat)
+	}
+	if !isSupportedNotifyFormat(output) {
+		return "", fmt.Errorf("invalid output format: %s", outputFormat)
+	}
+	if input == output {
+		return content, nil
+	}
+
+	switch input {
+	case "markdown":
+		if output == "html" {
+			return markdownToHTML(content), nil
+		}
+		if output == "text" {
+			return htmlToText(markdownToHTML(content)), nil
+		}
+	case "html":
+		if output == "text" || output == "markdown" {
+			return htmlToText(content), nil
+		}
+	case "text":
+		if output == "html" {
+			return textToHTML(content), nil
+		}
+	}
+
+	return content, nil
+}
+
+func isSupportedNotifyFormat(format string) bool {
+	switch format {
+	case "html", "markdown", "text":
+		return true
+	default:
+		return false
+	}
 }
 
 func textToHTML(content string) string {

--- a/internal/notify/format_convert_test.go
+++ b/internal/notify/format_convert_test.go
@@ -1,35 +1,60 @@
-package notify
+package notify_test
 
 import (
 	"strings"
 	"testing"
+
+	"github.com/unraid/apprise-go/internal/notify"
+	"github.com/unraid/apprise-go/internal/testutil"
 )
 
 func TestConvertMessageFormatMarkdownToHTML(t *testing.T) {
-	converted, err := ConvertMessageFormat("_This is Italics Text_", "markdown", "html")
-	if err != nil {
-		t.Fatalf("convert: %v", err)
-	}
-	if !strings.Contains(converted, "<em>This is Italics Text</em>") {
-		t.Fatalf("expected markdown converted to HTML, got %q", converted)
-	}
+	assertConvertMessageFormatRequestParity(t, "_This is Italics Text_", "markdown", "html")
 }
 
 func TestConvertMessageFormatHTMLToText(t *testing.T) {
-	converted, err := ConvertMessageFormat("<b>This is Bold Text</b>", "html", "text")
-	if err != nil {
-		t.Fatalf("convert: %v", err)
-	}
-	if converted != "This is Bold Text" {
-		t.Fatalf("expected plain text, got %q", converted)
-	}
+	assertConvertMessageFormatRequestParity(t, "<b>This is Bold Text</b>", "html", "text")
+}
+
+func TestConvertMessageFormatHTMLToMarkdownMatchesPythonFallback(t *testing.T) {
+	assertConvertMessageFormatRequestParity(t, "<b>This is Bold Text</b>", "html", "markdown")
 }
 
 func TestConvertMessageFormatRejectsInvalidFormats(t *testing.T) {
-	if _, err := ConvertMessageFormat("body", "bad", "html"); err == nil {
+	if _, err := notify.ConvertMessageFormat("body", "bad", "html"); err == nil {
 		t.Fatalf("expected invalid input format error")
 	}
-	if _, err := ConvertMessageFormat("body", "text", "bad"); err == nil {
+	if _, err := notify.ConvertMessageFormat("body", "text", "bad"); err == nil {
 		t.Fatalf("expected invalid output format error")
 	}
+}
+
+func assertConvertMessageFormatRequestParity(t *testing.T, body, inputFormat, outputFormat string) {
+	t.Helper()
+	testutil.RequirePythonApprise(t)
+
+	url := "json://example.com/notify?format=" + outputFormat
+	pythonSpecs := testutil.CapturePythonRequestsWithFormat(t, url, body, "", inputFormat)
+
+	converted, err := notify.ConvertMessageFormat(body, inputFormat, outputFormat)
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if outputFormat == "html" && !strings.Contains(converted, "<em>This is Italics Text</em>") {
+		t.Fatalf("expected markdown converted to HTML, got %q", converted)
+	}
+
+	parsed, err := notify.ParseURL(url)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	target, err := notify.NewJSONTarget(parsed)
+	if err != nil {
+		t.Fatalf("new json target: %v", err)
+	}
+	goSpecs := testutil.CaptureGoRequests(t, func() error {
+		return target.Send(converted, "", notify.NotifyInfo)
+	})
+
+	testutil.AssertRequestSpecSequenceMatches(t, pythonSpecs, goSpecs)
 }

--- a/internal/notify/format_convert_test.go
+++ b/internal/notify/format_convert_test.go
@@ -1,0 +1,35 @@
+package notify
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConvertMessageFormatMarkdownToHTML(t *testing.T) {
+	converted, err := ConvertMessageFormat("_This is Italics Text_", "markdown", "html")
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if !strings.Contains(converted, "<em>This is Italics Text</em>") {
+		t.Fatalf("expected markdown converted to HTML, got %q", converted)
+	}
+}
+
+func TestConvertMessageFormatHTMLToText(t *testing.T) {
+	converted, err := ConvertMessageFormat("<b>This is Bold Text</b>", "html", "text")
+	if err != nil {
+		t.Fatalf("convert: %v", err)
+	}
+	if converted != "This is Bold Text" {
+		t.Fatalf("expected plain text, got %q", converted)
+	}
+}
+
+func TestConvertMessageFormatRejectsInvalidFormats(t *testing.T) {
+	if _, err := ConvertMessageFormat("body", "bad", "html"); err == nil {
+		t.Fatalf("expected invalid input format error")
+	}
+	if _, err := ConvertMessageFormat("body", "text", "bad"); err == nil {
+		t.Fatalf("expected invalid output format error")
+	}
+}

--- a/internal/notify/mailto_format_test.go
+++ b/internal/notify/mailto_format_test.go
@@ -28,7 +28,7 @@ func TestMailtoHTMLFormatAcceptsConvertedMarkdownBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("smtp host split failed: %v", err)
 	}
-	rawURL := fmt.Sprintf("mailto://%s:%s/recipient@example.com?from=sender@example.com&format=html&mode=insecure", host, port)
+	rawURL := fmt.Sprintf("mailto://%s/recipient@example.com?from=sender@example.com&format=html&mode=insecure", net.JoinHostPort(host, port))
 
 	script := filepath.Join(testutil.RepoRoot(t), "internal", "testutil", "scripts", "capture_smtp.py")
 	stdout, stderr, err := testutil.RunPythonScript(

--- a/internal/notify/mailto_format_test.go
+++ b/internal/notify/mailto_format_test.go
@@ -53,7 +53,6 @@ func TestMailtoHTMLFormatAcceptsConvertedMarkdownBody(t *testing.T) {
 	if len(pythonMessages) == 0 {
 		t.Fatalf("no smtp message captured from python")
 	}
-	pythonMessage := pythonMessages[len(pythonMessages)-1]
 
 	capture.Reset()
 
@@ -77,11 +76,10 @@ func TestMailtoHTMLFormatAcceptsConvertedMarkdownBody(t *testing.T) {
 	if len(goMessages) == 0 {
 		t.Fatalf("no smtp message captured from go")
 	}
-	goMessage := goMessages[len(goMessages)-1]
 
-	testutil.AssertSMTPMessagesMatch(t, pythonMessage, goMessage)
+	testutil.AssertSMTPMessageSequencesMatch(t, pythonMessages, goMessages)
 
-	normalized := testutil.NormalizeSMTPMessage(t, goMessage)
+	normalized := testutil.NormalizeSMTPMessage(t, goMessages[0])
 	if !strings.Contains(normalized.Body, "<em>This is Italics Text</em>") {
 		t.Fatalf("expected converted markdown in html part, got %s", normalized.Body)
 	}

--- a/internal/notify/mailto_format_test.go
+++ b/internal/notify/mailto_format_test.go
@@ -1,0 +1,35 @@
+package notify
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestMailtoHTMLFormatAcceptsConvertedMarkdownBody(t *testing.T) {
+	parsed, err := ParseURL("mailto://smtp.example.com/recipient@example.com?from=sender@example.com&format=html")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	target, err := NewMailtoTarget(parsed)
+	if err != nil {
+		t.Fatalf("new mailto target: %v", err)
+	}
+	body, err := ConvertMessageFormat("_This is Italics Text_", "markdown", "html")
+	if err != nil {
+		t.Fatalf("convert body: %v", err)
+	}
+
+	messages, err := target.buildMessages(body, "subject")
+	if err != nil {
+		t.Fatalf("build messages: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("expected one message, got %d", len(messages))
+	}
+	if !strings.Contains(messages[0].body, "Content-Type: text/html") {
+		t.Fatalf("expected html part, got %s", messages[0].body)
+	}
+	if !strings.Contains(messages[0].body, "<em>This is Italics Text</em>") {
+		t.Fatalf("expected converted markdown in html part, got %s", messages[0].body)
+	}
+}

--- a/internal/notify/mailto_format_test.go
+++ b/internal/notify/mailto_format_test.go
@@ -1,35 +1,88 @@
-package notify
+package notify_test
 
 import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/unraid/apprise-go/internal/notify"
+	"github.com/unraid/apprise-go/internal/testutil"
 )
 
+type smtpFormatSendResult struct {
+	Success bool `json:"success"`
+}
+
 func TestMailtoHTMLFormatAcceptsConvertedMarkdownBody(t *testing.T) {
-	parsed, err := ParseURL("mailto://smtp.example.com/recipient@example.com?from=sender@example.com&format=html")
+	testutil.RequirePythonApprise(t)
+
+	capture := testutil.StartSMTPCapture(t)
+	defer func() {
+		_ = capture.Close()
+	}()
+
+	host, port, err := net.SplitHostPort(capture.Addr())
+	if err != nil {
+		t.Fatalf("smtp host split failed: %v", err)
+	}
+	rawURL := fmt.Sprintf("mailto://%s:%s/recipient@example.com?from=sender@example.com&format=html&mode=insecure", host, port)
+
+	script := filepath.Join(testutil.RepoRoot(t), "internal", "testutil", "scripts", "capture_smtp.py")
+	stdout, stderr, err := testutil.RunPythonScript(
+		t,
+		script,
+		"--url", rawURL,
+		"--body", "_This is Italics Text_",
+		"--title", "subject",
+		"--body-format", "markdown",
+	)
+	if err != nil {
+		t.Fatalf("python smtp send failed: %v (stderr: %s)", err, strings.TrimSpace(stderr))
+	}
+	var result smtpFormatSendResult
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		t.Fatalf("parse python smtp result failed: %v (stdout: %s)", err, strings.TrimSpace(stdout))
+	}
+	if !result.Success {
+		t.Fatalf("python smtp send reported failure: %s", strings.TrimSpace(stdout))
+	}
+	pythonMessages := capture.Messages()
+	if len(pythonMessages) == 0 {
+		t.Fatalf("no smtp message captured from python")
+	}
+	pythonMessage := pythonMessages[len(pythonMessages)-1]
+
+	capture.Reset()
+
+	parsed, err := notify.ParseURL(rawURL)
 	if err != nil {
 		t.Fatalf("parse url: %v", err)
 	}
-	target, err := NewMailtoTarget(parsed)
+	target, err := notify.NewMailtoTarget(parsed)
 	if err != nil {
 		t.Fatalf("new mailto target: %v", err)
 	}
-	body, err := ConvertMessageFormat("_This is Italics Text_", "markdown", "html")
+	body, err := notify.ConvertMessageFormat("_This is Italics Text_", "markdown", "html")
 	if err != nil {
 		t.Fatalf("convert body: %v", err)
 	}
 
-	messages, err := target.buildMessages(body, "subject")
-	if err != nil {
-		t.Fatalf("build messages: %v", err)
+	if err := target.Send(body, "subject", notify.NotifyInfo); err != nil {
+		t.Fatalf("go mailto send failed: %v", err)
 	}
-	if len(messages) != 1 {
-		t.Fatalf("expected one message, got %d", len(messages))
+	goMessages := capture.Messages()
+	if len(goMessages) == 0 {
+		t.Fatalf("no smtp message captured from go")
 	}
-	if !strings.Contains(messages[0].body, "Content-Type: text/html") {
-		t.Fatalf("expected html part, got %s", messages[0].body)
-	}
-	if !strings.Contains(messages[0].body, "<em>This is Italics Text</em>") {
-		t.Fatalf("expected converted markdown in html part, got %s", messages[0].body)
+	goMessage := goMessages[len(goMessages)-1]
+
+	testutil.AssertSMTPMessagesMatch(t, pythonMessage, goMessage)
+
+	normalized := testutil.NormalizeSMTPMessage(t, goMessage)
+	if !strings.Contains(normalized.Body, "<em>This is Italics Text</em>") {
+		t.Fatalf("expected converted markdown in html part, got %s", normalized.Body)
 	}
 }

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -21,6 +21,8 @@ type telegramRecipient struct {
 type TelegramTarget struct {
 	botToken     string
 	targets      []telegramRecipient
+	notifyFormat string
+	markdownMode string
 	silent       bool
 	preview      bool
 	detect       bool
@@ -73,9 +75,21 @@ func NewTelegramTarget(target *ParsedURL) (*TelegramTarget, error) {
 
 	detect := parseBoolValue(target.Query["detect"], len(targets) == 0)
 
+	format := normalizeNotifyFormat(target.Query["format"])
+	if format == "" {
+		format = "html"
+	}
+	switch format {
+	case "html", "markdown", "text":
+	default:
+		return nil, fmt.Errorf("invalid format")
+	}
+
 	return &TelegramTarget{
 		botToken:     botToken,
 		targets:      targets,
+		notifyFormat: format,
+		markdownMode: telegramMarkdownMode(target.Query["mdv"]),
 		silent:       parseBoolValue(target.Query["silent"], false),
 		preview:      parseBoolValue(target.Query["preview"], false),
 		detect:       detect,
@@ -91,7 +105,7 @@ func (t *TelegramTarget) BuildRequest(body, title string, notifyType NotifyType)
 		return RequestSpec{}, fmt.Errorf("missing targets")
 	}
 
-	message := formatTelegramMessage(title, body)
+	message := formatTelegramMessage(title, body, t.notifyFormat)
 	spec, err := t.buildSpec(message, t.targets[0])
 	if err != nil {
 		return RequestSpec{}, err
@@ -110,7 +124,7 @@ func (t *TelegramTarget) Send(body, title string, notifyType NotifyType) error {
 		return nil
 	}
 
-	message := formatTelegramMessage(title, body)
+	message := formatTelegramMessage(title, body, t.notifyFormat)
 	for _, recipient := range t.targets {
 		if t.includeImage {
 			spec, err := t.buildImageSpec(recipient)
@@ -139,8 +153,10 @@ func (t *TelegramTarget) buildSpec(body string, recipient telegramRecipient) (Re
 	payload := map[string]any{
 		"disable_notification":     t.silent,
 		"disable_web_page_preview": !t.preview,
-		"parse_mode":               "HTML",
 		"text":                     body,
+	}
+	if parseMode := t.parseMode(); parseMode != "" {
+		payload["parse_mode"] = parseMode
 	}
 
 	if recipient.isNumeric {
@@ -285,15 +301,59 @@ func parseOptionalIntValue(raw string) *int {
 	return &value
 }
 
-func formatTelegramMessage(title, body string) string {
+func (t *TelegramTarget) parseMode() string {
+	switch t.notifyFormat {
+	case "html":
+		return "HTML"
+	case "markdown":
+		return t.markdownMode
+	default:
+		return ""
+	}
+}
+
+func telegramMarkdownMode(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "v2", "markdownv2":
+		return "MarkdownV2"
+	default:
+		return "Markdown"
+	}
+}
+
+func formatTelegramMessage(title, body, format string) string {
 	if title == "" {
-		return html.EscapeString(body)
+		if format == "text" || format == "markdown" {
+			return body
+		}
+		return body
 	}
-	escapedTitle := html.EscapeString(title)
 	if body == "" {
-		return "<b>" + escapedTitle + "</b>"
+		return formatTelegramTitle(title, format)
 	}
-	return "<b>" + escapedTitle + "</b>\r\n" + html.EscapeString(body)
+	return formatTelegramTitle(title, format) + "\r\n" + body
+}
+
+func formatTelegramTitle(title, format string) string {
+	switch format {
+	case "html":
+		return "<b>" + html.EscapeString(title) + "</b>"
+	case "markdown":
+		return "*" + escapeTelegramMarkdownTitle(title) + "*"
+	default:
+		return title
+	}
+}
+
+func escapeTelegramMarkdownTitle(title string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		"*", "\\*",
+		"_", "\\_",
+		"`", "\\`",
+		"[", "\\[",
+	)
+	return replacer.Replace(title)
 }
 
 func init() {

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -105,7 +105,7 @@ func (t *TelegramTarget) BuildRequest(body, title string, notifyType NotifyType)
 		return RequestSpec{}, fmt.Errorf("missing targets")
 	}
 
-	message := formatTelegramMessage(title, body, t.notifyFormat)
+	message := formatTelegramMessage(title, body, t.notifyFormat, t.markdownMode)
 	spec, err := t.buildSpec(message, t.targets[0])
 	if err != nil {
 		return RequestSpec{}, err
@@ -124,7 +124,7 @@ func (t *TelegramTarget) Send(body, title string, notifyType NotifyType) error {
 		return nil
 	}
 
-	message := formatTelegramMessage(title, body, t.notifyFormat)
+	message := formatTelegramMessage(title, body, t.notifyFormat, t.markdownMode)
 	for _, recipient := range t.targets {
 		if t.includeImage {
 			spec, err := t.buildImageSpec(recipient)
@@ -321,7 +321,7 @@ func telegramMarkdownMode(raw string) string {
 	}
 }
 
-func formatTelegramMessage(title, body, format string) string {
+func formatTelegramMessage(title, body, format, markdownMode string) string {
 	if title == "" {
 		if format == "text" || format == "markdown" {
 			return body
@@ -329,23 +329,48 @@ func formatTelegramMessage(title, body, format string) string {
 		return body
 	}
 	if body == "" {
-		return formatTelegramTitle(title, format)
+		return formatTelegramTitle(title, format, markdownMode)
 	}
-	return formatTelegramTitle(title, format) + "\r\n" + body
+	return formatTelegramTitle(title, format, markdownMode) + "\r\n" + body
 }
 
-func formatTelegramTitle(title, format string) string {
+func formatTelegramTitle(title, format, markdownMode string) string {
 	switch format {
 	case "html":
 		return "<b>" + html.EscapeString(title) + "</b>"
 	case "markdown":
-		return "*" + escapeTelegramMarkdownTitle(title) + "*"
+		return "*" + escapeTelegramMarkdownTitle(title, markdownMode) + "*"
 	default:
 		return title
 	}
 }
 
-func escapeTelegramMarkdownTitle(title string) string {
+func escapeTelegramMarkdownTitle(title, markdownMode string) string {
+	if markdownMode == "MarkdownV2" {
+		replacer := strings.NewReplacer(
+			"\\", "\\\\",
+			"_", "\\_",
+			"*", "\\*",
+			"[", "\\[",
+			"]", "\\]",
+			"(", "\\(",
+			")", "\\)",
+			"~", "\\~",
+			"`", "\\`",
+			">", "\\>",
+			"#", "\\#",
+			"+", "\\+",
+			"-", "\\-",
+			"=", "\\=",
+			"|", "\\|",
+			"{", "\\{",
+			"}", "\\}",
+			".", "\\.",
+			"!", "\\!",
+		)
+		return replacer.Replace(title)
+	}
+
 	replacer := strings.NewReplacer(
 		"\\", "\\\\",
 		"*", "\\*",

--- a/internal/notify/telegram_format_test.go
+++ b/internal/notify/telegram_format_test.go
@@ -1,0 +1,89 @@
+package notify
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestTelegramHTMLFormatSendsUnescapedHTML(t *testing.T) {
+	target := mustTelegramTarget(t, "tgram://123456:abcdef/7890/?format=html")
+
+	spec, err := target.BuildRequest("<b>This is Bold Text</b>", "", NotifyInfo)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	payload := decodeTelegramPayload(t, spec.Body)
+	if payload["parse_mode"] != "HTML" {
+		t.Fatalf("expected HTML parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "<b>This is Bold Text</b>" {
+		t.Fatalf("expected unescaped HTML body, got %#v", payload["text"])
+	}
+}
+
+func TestTelegramMarkdownFormatSetsMarkdownParseMode(t *testing.T) {
+	target := mustTelegramTarget(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v1")
+
+	spec, err := target.BuildRequest("_This is Italics Text_", "", NotifyInfo)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	payload := decodeTelegramPayload(t, spec.Body)
+	if payload["parse_mode"] != "Markdown" {
+		t.Fatalf("expected Markdown parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "_This is Italics Text_" {
+		t.Fatalf("expected markdown body, got %#v", payload["text"])
+	}
+}
+
+func TestTelegramTextFormatOmitsParseMode(t *testing.T) {
+	target := mustTelegramTarget(t, "tgram://123456:abcdef/7890/?format=text")
+
+	spec, err := target.BuildRequest("<b>plain</b>", "Title", NotifyInfo)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	payload := decodeTelegramPayload(t, spec.Body)
+	if _, ok := payload["parse_mode"]; ok {
+		t.Fatalf("did not expect parse mode for text format: %#v", payload)
+	}
+	if payload["text"] != "Title\r\n<b>plain</b>" {
+		t.Fatalf("expected plain text title/body, got %#v", payload["text"])
+	}
+}
+
+func TestTelegramRejectsInvalidFormat(t *testing.T) {
+	parsed, err := ParseURL("tgram://123456:abcdef/7890/?format=bad")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	if _, err := NewTelegramTarget(parsed); err == nil {
+		t.Fatalf("expected invalid format error")
+	}
+}
+
+func mustTelegramTarget(t *testing.T, raw string) *TelegramTarget {
+	t.Helper()
+	parsed, err := ParseURL(raw)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	target, err := NewTelegramTarget(parsed)
+	if err != nil {
+		t.Fatalf("new telegram target: %v", err)
+	}
+	return target
+}
+
+func decodeTelegramPayload(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	return payload
+}

--- a/internal/notify/telegram_format_test.go
+++ b/internal/notify/telegram_format_test.go
@@ -1,78 +1,91 @@
-package notify
+package notify_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
+
+	"github.com/unraid/apprise-go/internal/notify"
+	"github.com/unraid/apprise-go/internal/testutil"
 )
 
 func TestTelegramHTMLFormatSendsUnescapedHTML(t *testing.T) {
-	target := mustTelegramTarget(t, "tgram://123456:abcdef/7890/?format=html")
-
-	spec, err := target.BuildRequest("<b>This is Bold Text</b>", "", NotifyInfo)
-	if err != nil {
-		t.Fatalf("build request: %v", err)
-	}
-
-	payload := decodeTelegramPayload(t, spec.Body)
-	if payload["parse_mode"] != "HTML" {
-		t.Fatalf("expected HTML parse mode, got %#v", payload["parse_mode"])
-	}
-	if payload["text"] != "<b>This is Bold Text</b>" {
-		t.Fatalf("expected unescaped HTML body, got %#v", payload["text"])
-	}
+	assertTelegramFormatParity(t, "tgram://123456:abcdef/7890/?format=html", "<b>This is Bold Text</b>", "", "html")
 }
 
 func TestTelegramMarkdownFormatSetsMarkdownParseMode(t *testing.T) {
-	target := mustTelegramTarget(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v1")
-
-	spec, err := target.BuildRequest("_This is Italics Text_", "", NotifyInfo)
-	if err != nil {
-		t.Fatalf("build request: %v", err)
-	}
-
-	payload := decodeTelegramPayload(t, spec.Body)
-	if payload["parse_mode"] != "Markdown" {
-		t.Fatalf("expected Markdown parse mode, got %#v", payload["parse_mode"])
-	}
-	if payload["text"] != "_This is Italics Text_" {
-		t.Fatalf("expected markdown body, got %#v", payload["text"])
-	}
+	assertTelegramFormatParity(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v1", "_This is Italics Text_", "", "markdown")
 }
 
 func TestTelegramTextFormatOmitsParseMode(t *testing.T) {
-	target := mustTelegramTarget(t, "tgram://123456:abcdef/7890/?format=text")
-
-	spec, err := target.BuildRequest("<b>plain</b>", "Title", NotifyInfo)
-	if err != nil {
-		t.Fatalf("build request: %v", err)
-	}
-
-	payload := decodeTelegramPayload(t, spec.Body)
-	if _, ok := payload["parse_mode"]; ok {
-		t.Fatalf("did not expect parse mode for text format: %#v", payload)
-	}
-	if payload["text"] != "Title\r\n<b>plain</b>" {
-		t.Fatalf("expected plain text title/body, got %#v", payload["text"])
-	}
+	assertTelegramFormatParity(t, "tgram://123456:abcdef/7890/?format=text", "<b>plain</b>", "Title", "text")
 }
 
 func TestTelegramRejectsInvalidFormat(t *testing.T) {
-	parsed, err := ParseURL("tgram://123456:abcdef/7890/?format=bad")
+	parsed, err := notify.ParseURL("tgram://123456:abcdef/7890/?format=bad")
 	if err != nil {
 		t.Fatalf("parse url: %v", err)
 	}
-	if _, err := NewTelegramTarget(parsed); err == nil {
+	if _, err := notify.NewTelegramTarget(parsed); err == nil {
 		t.Fatalf("expected invalid format error")
 	}
 }
 
-func mustTelegramTarget(t *testing.T, raw string) *TelegramTarget {
+func TestTelegramMarkdownV2TitleEscapesReservedCharacters(t *testing.T) {
+	target := mustTelegramTarget(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v2")
+
+	spec, err := target.BuildRequest("body", `\_*[]()~`+"`"+`>#+-=|{}.!`, notify.NotifyInfo)
+	if err != nil {
+		t.Fatalf("build request: %v", err)
+	}
+
+	payload := decodeTelegramPayload(t, spec.Body)
+	if payload["parse_mode"] != "MarkdownV2" {
+		t.Fatalf("expected MarkdownV2 parse mode, got %#v", payload["parse_mode"])
+	}
+	text, ok := payload["text"].(string)
+	if !ok {
+		t.Fatalf("expected text payload, got %#v", payload["text"])
+	}
+	for _, escaped := range []string{`\\`, `\_`, `\*`, `\[`, `\]`, `\(`, `\)`, `\~`, "\\`", `\>`, `\#`, `\+`, `\-`, `\=`, `\|`, `\{`, `\}`, `\.`, `\!`} {
+		if !strings.Contains(text, escaped) {
+			t.Fatalf("expected escaped fragment %q in %q", escaped, text)
+		}
+	}
+}
+
+func assertTelegramFormatParity(t *testing.T, rawURL, body, title, bodyFormat string) {
 	t.Helper()
-	parsed, err := ParseURL(raw)
+	testutil.RequirePythonApprise(t)
+
+	pythonSpecs := testutil.CapturePythonRequestsWithFormat(t, rawURL, body, title, bodyFormat)
+
+	parsed, err := notify.ParseURL(rawURL)
 	if err != nil {
 		t.Fatalf("parse url: %v", err)
 	}
-	target, err := NewTelegramTarget(parsed)
+	target, err := notify.NewTelegramTarget(parsed)
+	if err != nil {
+		t.Fatalf("new telegram target: %v", err)
+	}
+	convertedBody, err := notify.ConvertMessageFormat(body, bodyFormat, parsed.Query["format"])
+	if err != nil {
+		t.Fatalf("convert body: %v", err)
+	}
+	goSpecs := testutil.CaptureGoRequests(t, func() error {
+		return target.Send(convertedBody, title, notify.NotifyInfo)
+	})
+
+	testutil.AssertRequestSpecSequenceMatches(t, pythonSpecs, goSpecs)
+}
+
+func mustTelegramTarget(t *testing.T, raw string) *notify.TelegramTarget {
+	t.Helper()
+	parsed, err := notify.ParseURL(raw)
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	target, err := notify.NewTelegramTarget(parsed)
 	if err != nil {
 		t.Fatalf("new telegram target: %v", err)
 	}

--- a/internal/testutil/python.go
+++ b/internal/testutil/python.go
@@ -19,6 +19,20 @@ func PythonPath(t *testing.T) string {
 	return path
 }
 
+func RequirePythonApprise(t *testing.T) {
+	t.Helper()
+
+	path := filepath.Join(VenvBinDir(t), "python")
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("python not found in venv: %s", path)
+	}
+
+	_, stderr, err := RunCommand(t, path, "-c", "import apprise")
+	if err != nil {
+		t.Fatalf("python apprise import failed: %v (stderr: %s)", err, stderr)
+	}
+}
+
 func AppriseCLIPath(t *testing.T) string {
 	t.Helper()
 

--- a/internal/testutil/request_compare.go
+++ b/internal/testutil/request_compare.go
@@ -1,0 +1,260 @@
+package testutil
+
+import (
+	"encoding/json"
+	"net/url"
+	"reflect"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/unraid/apprise-go/internal/notify"
+)
+
+var requestHeaderDrop = map[string]struct{}{
+	"x-apprise-id":              {},
+	"x-apprise-recursion-count": {},
+}
+
+var requestHeaderKeep = map[string]struct{}{
+	"user-agent":    {},
+	"content-type":  {},
+	"accept":        {},
+	"accepts":       {},
+	"authorization": {},
+}
+
+const (
+	appriseUpstreamAssetPrefix = "https://github.com/caronc/apprise/raw/master/apprise/assets/themes/default/apprise-"
+	appriseGoAssetPrefix       = "https://raw.githubusercontent.com/unraid/apprise-go/main/assets/themes/default/apprise-"
+	appriseUpstreamRepoURL     = "https://github.com/caronc/apprise"
+	appriseGoRepoURL           = "https://github.com/unraid/apprise-go"
+)
+
+func AssertRequestSpecSequenceMatches(t *testing.T, pythonSpecs, goSpecs []notify.RequestSpec) {
+	t.Helper()
+
+	if len(pythonSpecs) != len(goSpecs) {
+		t.Fatalf("request count mismatch: python=%d go=%d", len(pythonSpecs), len(goSpecs))
+	}
+
+	for i := range pythonSpecs {
+		assertRequestSpecMatches(t, pythonSpecs[i], goSpecs[i])
+	}
+}
+
+func assertRequestSpecMatches(t *testing.T, pythonSpec, goSpec notify.RequestSpec) {
+	t.Helper()
+
+	if strings.ToUpper(pythonSpec.Method) != strings.ToUpper(goSpec.Method) {
+		t.Fatalf("method mismatch: python=%s go=%s", pythonSpec.Method, goSpec.Method)
+	}
+
+	pythonBody := normalizeRequestBody(pythonSpec)
+	goBody := normalizeRequestBody(goSpec)
+
+	pythonURL, err := url.Parse(pythonSpec.URL)
+	if err != nil {
+		t.Fatalf("parse python url: %v", err)
+	}
+	goURL, err := url.Parse(goSpec.URL)
+	if err != nil {
+		t.Fatalf("parse go url: %v", err)
+	}
+	if pythonURL.Scheme != goURL.Scheme || pythonURL.Host != goURL.Host || pythonURL.Path != goURL.Path || pythonURL.Fragment != goURL.Fragment {
+		t.Fatalf("url mismatch: python=%s go=%s", pythonSpec.URL, goSpec.URL)
+	}
+	pythonQuery := normalizeRequestQueryValues(pythonURL.Query()).Encode()
+	goQuery := normalizeRequestQueryValues(goURL.Query()).Encode()
+	if pythonQuery != goQuery {
+		t.Fatalf("url query mismatch: python=%s go=%s", pythonQuery, goQuery)
+	}
+
+	pythonHeaders := NormalizeRequestHeaders(pythonSpec.Headers)
+	goHeaders := NormalizeRequestHeaders(goSpec.Headers)
+	if !reflect.DeepEqual(pythonHeaders, goHeaders) {
+		t.Fatalf("header mismatch: python=%v go=%v", pythonHeaders, goHeaders)
+	}
+
+	if shouldCompareRequestJSON(pythonHeaders) && strings.TrimSpace(pythonBody) != "" && strings.TrimSpace(goBody) != "" {
+		assertRequestJSONBodyEqual(t, pythonBody, goBody)
+		return
+	}
+	if shouldCompareRequestBodyAsJSON(pythonBody, goBody) {
+		assertRequestJSONBodyEqual(t, pythonBody, goBody)
+		return
+	}
+	if shouldCompareRequestForm(pythonHeaders, pythonBody) {
+		assertRequestQueryEqual(t, pythonBody, goBody)
+		return
+	}
+
+	if pythonBody != goBody {
+		t.Fatalf("body mismatch: python=%s go=%s", pythonBody, goBody)
+	}
+}
+
+func NormalizeRequestHeaders(headers map[string]string) map[string]string {
+	normalized := map[string]string{}
+	for key, value := range headers {
+		lower := strings.ToLower(key)
+		if _, drop := requestHeaderDrop[lower]; drop {
+			continue
+		}
+		if _, keep := requestHeaderKeep[lower]; keep || strings.HasPrefix(lower, "x-") {
+			normalized[lower] = normalizeAppriseURL(value)
+		}
+	}
+
+	sorted := make([]string, 0, len(normalized))
+	for key := range normalized {
+		sorted = append(sorted, key)
+	}
+	sort.Strings(sorted)
+
+	ordered := map[string]string{}
+	for _, key := range sorted {
+		ordered[key] = normalized[key]
+	}
+
+	return ordered
+}
+
+func normalizeRequestBody(spec notify.RequestSpec) string {
+	body := spec.Body
+	if strings.TrimSpace(body) == "" {
+		return ""
+	}
+	if strings.EqualFold(spec.Method, "GET") && strings.TrimSpace(body) == "null" {
+		return ""
+	}
+	return body
+}
+
+func shouldCompareRequestJSON(headers map[string]string) bool {
+	contentType := strings.ToLower(headers["content-type"])
+	return strings.Contains(contentType, "application/json")
+}
+
+func shouldCompareRequestForm(headers map[string]string, body string) bool {
+	contentType := strings.ToLower(headers["content-type"])
+	if !strings.Contains(contentType, "application/x-www-form-urlencoded") {
+		return false
+	}
+	return strings.Contains(body, "=")
+}
+
+func shouldCompareRequestBodyAsJSON(pythonBody, goBody string) bool {
+	if strings.TrimSpace(pythonBody) == "" || strings.TrimSpace(goBody) == "" {
+		return false
+	}
+	var pythonValue any
+	if err := json.Unmarshal([]byte(pythonBody), &pythonValue); err != nil {
+		return false
+	}
+	var goValue any
+	if err := json.Unmarshal([]byte(goBody), &goValue); err != nil {
+		return false
+	}
+	return true
+}
+
+func assertRequestJSONBodyEqual(t *testing.T, pythonBody, goBody string) {
+	t.Helper()
+
+	var pythonValue any
+	var goValue any
+	if err := json.Unmarshal([]byte(pythonBody), &pythonValue); err != nil {
+		t.Fatalf("parse python json body: %v", err)
+	}
+	if err := json.Unmarshal([]byte(goBody), &goValue); err != nil {
+		t.Fatalf("parse go json body: %v", err)
+	}
+
+	pythonValue = normalizeRequestJSONValue(pythonValue)
+	goValue = normalizeRequestJSONValue(goValue)
+
+	if !reflect.DeepEqual(pythonValue, goValue) {
+		t.Fatalf("json body mismatch: python=%v go=%v", pythonValue, goValue)
+	}
+}
+
+func assertRequestQueryEqual(t *testing.T, pythonBody, goBody string) {
+	t.Helper()
+
+	pythonValues, err := url.ParseQuery(pythonBody)
+	if err != nil {
+		t.Fatalf("parse python query: %v", err)
+	}
+	goValues, err := url.ParseQuery(goBody)
+	if err != nil {
+		t.Fatalf("parse go query: %v", err)
+	}
+
+	pythonNormalized := normalizeRequestQueryValues(pythonValues)
+	goNormalized := normalizeRequestQueryValues(goValues)
+
+	if pythonNormalized.Encode() != goNormalized.Encode() {
+		t.Fatalf("query mismatch: python=%s go=%s", pythonNormalized.Encode(), goNormalized.Encode())
+	}
+}
+
+func normalizeRequestQueryValues(values url.Values) url.Values {
+	normalized := url.Values{}
+	for key, list := range values {
+		clean := make([]string, len(list))
+		for i, value := range list {
+			clean[i] = normalizeRequestQueryValue(value)
+		}
+		normalized[key] = clean
+	}
+	return normalized
+}
+
+func normalizeRequestQueryValue(value string) string {
+	trimmed := strings.TrimSpace(value)
+	if strings.HasPrefix(trimmed, "{") || strings.HasPrefix(trimmed, "[") {
+		var parsed any
+		if err := json.Unmarshal([]byte(trimmed), &parsed); err == nil {
+			parsed = normalizeRequestJSONValue(parsed)
+			if normalized, err := json.Marshal(parsed); err == nil {
+				return string(normalized)
+			}
+		}
+	}
+	return normalizeAppriseURL(value)
+}
+
+func normalizeRequestJSONValue(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		normalized := make(map[string]any, len(typed))
+		for key, entry := range typed {
+			normalized[key] = normalizeRequestJSONValue(entry)
+		}
+		return normalized
+	case []any:
+		normalized := make([]any, len(typed))
+		for i, entry := range typed {
+			normalized[i] = normalizeRequestJSONValue(entry)
+		}
+		return normalized
+	case string:
+		return normalizeAppriseURL(typed)
+	default:
+		return typed
+	}
+}
+
+func normalizeAppriseURL(value string) string {
+	if strings.HasPrefix(value, appriseUpstreamAssetPrefix) {
+		return appriseGoAssetPrefix + strings.TrimPrefix(value, appriseUpstreamAssetPrefix)
+	}
+	if strings.HasPrefix(value, appriseGoAssetPrefix) {
+		return value
+	}
+	if value == appriseUpstreamRepoURL {
+		return appriseGoRepoURL
+	}
+	return value
+}

--- a/internal/testutil/request_compare.go
+++ b/internal/testutil/request_compare.go
@@ -46,7 +46,7 @@ func AssertRequestSpecSequenceMatches(t *testing.T, pythonSpecs, goSpecs []notif
 func assertRequestSpecMatches(t *testing.T, pythonSpec, goSpec notify.RequestSpec) {
 	t.Helper()
 
-	if strings.ToUpper(pythonSpec.Method) != strings.ToUpper(goSpec.Method) {
+	if !strings.EqualFold(pythonSpec.Method, goSpec.Method) {
 		t.Fatalf("method mismatch: python=%s go=%s", pythonSpec.Method, goSpec.Method)
 	}
 

--- a/internal/testutil/request_spec.go
+++ b/internal/testutil/request_spec.go
@@ -28,6 +28,34 @@ func CapturePythonRequestsWithType(t *testing.T, url, body, title string, notify
 	return specs
 }
 
+func CapturePythonRequestsWithFormat(t *testing.T, url, body, title, bodyFormat string) []notify.RequestSpec {
+	t.Helper()
+
+	specs, _ := CapturePythonRequestsWithFormatAndTypeResult(t, url, body, title, bodyFormat, notify.NotifyInfo)
+	return specs
+}
+
+func CapturePythonRequestsWithFormatAndTypeResult(t *testing.T, url, body, title, bodyFormat string, notifyType notify.NotifyType) ([]notify.RequestSpec, *bool) {
+	t.Helper()
+
+	script := filepath.Join(RepoRoot(t), "internal", "testutil", "scripts", "capture_request.py")
+	stdout, stderr, err := RunPythonScript(
+		t,
+		script,
+		"--url", url,
+		"--body", body,
+		"--title", title,
+		"--type", string(notifyType),
+		"--body-format", bodyFormat,
+	)
+	if err != nil {
+		t.Fatalf("capture request failed: %v (stderr: %s)", err, strings.TrimSpace(stderr))
+	}
+
+	payload := parsePythonCapturePayload(t, stdout)
+	return payload.Requests, payload.Success
+}
+
 func CapturePythonRequestsResult(t *testing.T, url, body, title string) ([]notify.RequestSpec, *bool) {
 	t.Helper()
 

--- a/internal/testutil/scripts/capture_request.py
+++ b/internal/testutil/scripts/capture_request.py
@@ -85,7 +85,7 @@ ensure_yaml()
 ensure_markdown()
 ensure_cryptography()
 
-from apprise.common import NotifyType
+from apprise.common import NotifyFormat, NotifyType
 
 import apprise
 from apprise import AppriseAsset
@@ -94,7 +94,7 @@ DROP_HEADERS = {"x-apprise-id", "x-apprise-recursion-count"}
 KEEP_HEADERS = {"content-type", "accept", "accepts", "authorization"}
 
 BLUESKY_CREATED_AT = "2024-01-01T00:00:00Z"
-CACHE_VERSION = 8
+CACHE_VERSION = 9
 CACHE_ENV = "APPRISE_CAPTURE_CACHE"
 CACHE_DIR_ENV = "APPRISE_CAPTURE_CACHE_DIR"
 CACHE_SUBDIR = ".tmp/pycapture"
@@ -163,7 +163,7 @@ def apprise_git_sha():
     return output.decode("utf-8", "replace").strip()
 
 
-def cache_key(url, body, title, notify_type):
+def cache_key(url, body, title, notify_type, body_format):
     notify_name = notify_type.name if hasattr(notify_type, "name") else str(notify_type)
     try:
         import apprise as apprise_module
@@ -177,6 +177,7 @@ def cache_key(url, body, title, notify_type):
         "body": body,
         "title": title,
         "notify_type": notify_name,
+        "body_format": body_format,
         "apprise_version": apprise_version,
         "apprise_sha": apprise_git_sha(),
         "python_version": sys.version,
@@ -203,10 +204,10 @@ def cache_key(url, body, title, notify_type):
     return digest
 
 
-def load_cache(url, body, title, notify_type):
+def load_cache(url, body, title, notify_type, body_format):
     if not cache_enabled():
         return None, None
-    digest = cache_key(url, body, title, notify_type)
+    digest = cache_key(url, body, title, notify_type, body_format)
     root = cache_dir()
     path = root / f"{digest}.json"
     if not path.exists():
@@ -413,8 +414,8 @@ def apply_simplepush_fixes():
         pass
 
 
-def capture_request(url, body, title, notify_type):
-    cached, cache_path = load_cache(url, body, title, notify_type)
+def capture_request(url, body, title, notify_type, body_format=None):
+    cached, cache_path = load_cache(url, body, title, notify_type, body_format)
     if cached is not None:
         return cached
 
@@ -646,7 +647,10 @@ def capture_request(url, body, title, notify_type):
 
     requests.sessions.Session.request = patched_request
     try:
-        asset = AppriseAsset()
+        asset_kwargs = {}
+        if body_format:
+            asset_kwargs["body_format"] = NotifyFormat(body_format)
+        asset = AppriseAsset(**asset_kwargs)
         service = apprise.Apprise(asset=asset)
         service.add(url)
         success = service.notify(
@@ -668,6 +672,7 @@ def main():
     parser.add_argument("--body", default="")
     parser.add_argument("--title", default="")
     parser.add_argument("--type", default="info")
+    parser.add_argument("--body-format", default="")
     args = parser.parse_args()
 
     notify_type = NotifyType.INFO
@@ -678,7 +683,8 @@ def main():
     elif args.type.lower() == "failure":
         notify_type = NotifyType.FAILURE
 
-    payload = capture_request(args.url, args.body, args.title, notify_type)
+    body_format = args.body_format.strip().lower() or None
+    payload = capture_request(args.url, args.body, args.title, notify_type, body_format)
     print(json.dumps(payload))
 
 

--- a/internal/testutil/scripts/capture_smtp.py
+++ b/internal/testutil/scripts/capture_smtp.py
@@ -3,6 +3,8 @@ import json
 import sys
 
 import apprise
+from apprise import AppriseAsset
+from apprise.common import NotifyFormat
 
 
 def main():
@@ -10,9 +12,15 @@ def main():
     parser.add_argument("--url", required=True)
     parser.add_argument("--body", default="")
     parser.add_argument("--title", default="")
+    parser.add_argument("--body-format", default="")
     args = parser.parse_args()
 
-    apobj = apprise.Apprise()
+    asset_kwargs = {}
+    body_format = args.body_format.strip().lower()
+    if body_format:
+        asset_kwargs["body_format"] = NotifyFormat(body_format)
+
+    apobj = apprise.Apprise(asset=AppriseAsset(**asset_kwargs))
     apobj.add(args.url)
     success = apobj.notify(body=args.body, title=args.title)
     print(json.dumps({"success": bool(success)}, ensure_ascii=True))

--- a/internal/testutil/smtp_compare.go
+++ b/internal/testutil/smtp_compare.go
@@ -40,6 +40,17 @@ func AssertSMTPMessagesMatch(t *testing.T, pythonMsg, goMsg SMTPMessage) {
 	}
 }
 
+func AssertSMTPMessageSequencesMatch(t *testing.T, pythonMsgs, goMsgs []SMTPMessage) {
+	t.Helper()
+
+	if len(pythonMsgs) != len(goMsgs) {
+		t.Fatalf("smtp message count mismatch: python=%d go=%d", len(pythonMsgs), len(goMsgs))
+	}
+	for i := range pythonMsgs {
+		AssertSMTPMessagesMatch(t, pythonMsgs[i], goMsgs[i])
+	}
+}
+
 func NormalizeSMTPMessage(t *testing.T, msg SMTPMessage) NormalizedSMTP {
 	t.Helper()
 

--- a/internal/testutil/smtp_compare.go
+++ b/internal/testutil/smtp_compare.go
@@ -1,0 +1,278 @@
+package testutil
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
+	"mime/quotedprintable"
+	"net/mail"
+	"sort"
+	"strings"
+	"testing"
+)
+
+type NormalizedSMTP struct {
+	MailFrom    string
+	RcptTo      []string
+	From        string
+	To          []string
+	Cc          []string
+	ReplyTo     []string
+	Subject     string
+	Body        string
+	ContentType string
+	AppID       string
+}
+
+func AssertSMTPMessagesMatch(t *testing.T, pythonMsg, goMsg SMTPMessage) {
+	t.Helper()
+
+	pythonNormalized := NormalizeSMTPMessage(t, pythonMsg)
+	goNormalized := NormalizeSMTPMessage(t, goMsg)
+
+	if !equalNormalizedSMTP(pythonNormalized, goNormalized) {
+		pyJSON, _ := json.Marshal(pythonNormalized)
+		goJSON, _ := json.Marshal(goNormalized)
+		t.Fatalf("smtp parity mismatch\npython=%s\ngo=%s", pyJSON, goJSON)
+	}
+}
+
+func NormalizeSMTPMessage(t *testing.T, msg SMTPMessage) NormalizedSMTP {
+	t.Helper()
+
+	parsed, err := mail.ReadMessage(strings.NewReader(msg.Data))
+	if err != nil {
+		t.Fatalf("parse smtp message failed: %v", err)
+	}
+
+	return NormalizedSMTP{
+		MailFrom:    normalizeSMTPAddress(msg.MailFrom),
+		RcptTo:      normalizeSMTPAddressList(msg.RcptTo),
+		From:        normalizeSMTPSingleHeaderAddress(parsed.Header.Get("From")),
+		To:          normalizeSMTPHeaderAddressList(parsed.Header.Get("To")),
+		Cc:          normalizeSMTPHeaderAddressList(parsed.Header.Get("Cc")),
+		ReplyTo:     normalizeSMTPHeaderAddressList(parsed.Header.Get("Reply-To")),
+		Subject:     decodeSMTPHeader(parsed.Header.Get("Subject")),
+		Body:        decodeSMTPBody(t, parsed.Header, parsed.Body),
+		ContentType: normalizeSMTPContentType(parsed.Header.Get("Content-Type")),
+		AppID:       strings.TrimSpace(parsed.Header.Get("X-Application")),
+	}
+}
+
+func normalizeSMTPAddress(value string) string {
+	return strings.ToLower(strings.TrimSpace(strings.Trim(value, "<>")))
+}
+
+func normalizeSMTPAddressList(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		normalized := normalizeSMTPAddress(value)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		out = append(out, normalized)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizeSMTPSingleHeaderAddress(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return ""
+	}
+	addr, err := mail.ParseAddress(value)
+	if err != nil {
+		return normalizeSMTPAddress(value)
+	}
+	return normalizeSMTPAddress(addr.Address)
+}
+
+func normalizeSMTPHeaderAddressList(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	list, err := mail.ParseAddressList(value)
+	if err != nil {
+		return normalizeSMTPAddressList(strings.Split(value, ","))
+	}
+	out := make([]string, 0, len(list))
+	for _, addr := range list {
+		out = append(out, normalizeSMTPAddress(addr.Address))
+	}
+	sort.Strings(out)
+	return out
+}
+
+func decodeSMTPHeader(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	decoder := mime.WordDecoder{}
+	decoded, err := decoder.DecodeHeader(value)
+	if err != nil {
+		return value
+	}
+	return decoded
+}
+
+func normalizeSMTPContentType(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return strings.ToLower(value)
+	}
+	return strings.ToLower(mediaType)
+}
+
+func decodeSMTPBody(t *testing.T, header mail.Header, body io.Reader) string {
+	t.Helper()
+
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read smtp body failed: %v", err)
+	}
+
+	contentType := header.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err == nil && strings.HasPrefix(strings.ToLower(mediaType), "multipart/") {
+		boundary := params["boundary"]
+		if boundary != "" {
+			return decodeMultipartBody(t, boundary, raw)
+		}
+	}
+
+	raw = decodeSMTPTransfer(t, header, raw)
+	out := string(raw)
+	out = strings.ReplaceAll(out, "\r\n", "\n")
+	out = strings.TrimRight(out, "\n")
+	return out
+}
+
+func decodeMultipartBody(t *testing.T, boundary string, raw []byte) string {
+	t.Helper()
+
+	reader := multipart.NewReader(bytes.NewReader(raw), boundary)
+	parts := []string{}
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("parse smtp multipart failed: %v", err)
+		}
+
+		partBody := decodeSMTPPartBody(t, mail.Header(part.Header), part)
+		partType := normalizeSMTPContentType(part.Header.Get("Content-Type"))
+		parts = append(parts, partType+"\n"+partBody)
+	}
+
+	return strings.Join(parts, "\n--PART--\n")
+}
+
+func decodeSMTPPartBody(t *testing.T, header mail.Header, body io.Reader) string {
+	t.Helper()
+
+	raw, err := io.ReadAll(body)
+	if err != nil {
+		t.Fatalf("read smtp part body failed: %v", err)
+	}
+	raw = decodeSMTPTransfer(t, header, raw)
+
+	out := string(raw)
+	out = strings.ReplaceAll(out, "\r\n", "\n")
+	out = strings.TrimRight(out, "\n")
+	return out
+}
+
+func decodeSMTPTransfer(t *testing.T, header mail.Header, raw []byte) []byte {
+	t.Helper()
+
+	encoding := strings.ToLower(strings.TrimSpace(header.Get("Content-Transfer-Encoding")))
+	switch encoding {
+	case "base64":
+		decoded, err := base64.StdEncoding.DecodeString(stripSMTPWhitespace(string(raw)))
+		if err == nil {
+			return decoded
+		}
+	case "quoted-printable":
+		reader := quotedprintable.NewReader(bytes.NewReader(raw))
+		decoded, err := io.ReadAll(reader)
+		if err == nil {
+			return decoded
+		}
+	}
+	return raw
+}
+
+func stripSMTPWhitespace(value string) string {
+	var b strings.Builder
+	for _, r := range value {
+		switch r {
+		case ' ', '\t', '\r', '\n':
+			continue
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}
+
+func equalNormalizedSMTP(a, b NormalizedSMTP) bool {
+	if a.MailFrom != b.MailFrom {
+		return false
+	}
+	if !equalStringSlice(a.RcptTo, b.RcptTo) {
+		return false
+	}
+	if a.From != b.From {
+		return false
+	}
+	if !equalStringSlice(a.To, b.To) {
+		return false
+	}
+	if !equalStringSlice(a.Cc, b.Cc) {
+		return false
+	}
+	if !equalStringSlice(a.ReplyTo, b.ReplyTo) {
+		return false
+	}
+	if a.Subject != b.Subject {
+		return false
+	}
+	if a.Body != b.Body {
+		return false
+	}
+	if a.ContentType != b.ContentType {
+		return false
+	}
+	if a.AppID != b.AppID {
+		return false
+	}
+	return true
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
## Summary
- Honor `-i/--input-format` by converting CLI body content into the target `format=` before provider dispatch.
- Preserve Telegram HTML and Markdown bodies by mapping `format=html`, `format=markdown`, and `format=text` to the appropriate Telegram payload `parse_mode`.
- Add full CLI-level and provider-level Python-vs-Go request parity assertions for formatted JSON, Telegram, and mailto paths.
- Extend Python capture helpers to accept body format so parity tests exercise the same conversion path as Python Apprise CLI/library sends.
- Escape Telegram MarkdownV2 title reserved characters.
- Address CodeRabbit follow-up feedback: CLI Telegram/mailto tests now use parity, mailto test URLs use `net.JoinHostPort`, and request method comparison uses `strings.EqualFold`.

Fixes #48.

## CodeRabbit Loop
- WIP checklist: `.codex/coderabbit-fixes-wip.md`
- Remaining blocked item: HTML -> Markdown conversion remains aligned with upstream Python Apprise, which currently falls back to HTML-to-text for that conversion.
- MarkdownV2 title parity request skipped because Python Apprise blends/escapes MarkdownV2 title/body differently from the Go-side hardening test.

## Validation
- `go test -count=1 ./internal/cli`
- `go test -count=1 ./internal/notify ./internal/cli`
- `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil`
- `go test -count=1 ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic conversion between plain text, HTML, and Markdown for notifications.
  * CLI converts message bodies to each target's requested format and continues on conversion errors.
  * Mailto deliveries can include HTML parts when HTML is requested.
  * Telegram notifications support HTML, Markdown (v1/v2), or plain-text modes via URL query, with proper escaping for MarkdownV2.

* **Tests**
  * Expanded end-to-end and unit tests validating format conversion, CLI behavior, mailto HTML, Telegram formatting, and parity against the Python reference.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/apprise-go/pull/50?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->