### PR TITLE
fix: config tag parity regressions

### DIFF
--- a/apprise_test.go
+++ b/apprise_test.go
@@ -1,7 +1,6 @@
 package apprise
 
 import (
-	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
@@ -10,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/unraid/apprise-go/internal/notify"
 	"github.com/unraid/apprise-go/internal/testutil"
 )
 
@@ -33,42 +33,34 @@ func TestAppriseSendJSONTarget(t *testing.T) {
 }
 
 func TestAppriseSendConvertsInputFormat(t *testing.T) {
-	requests := make(chan map[string]any, 1)
+	testutil.RequirePythonApprise(t)
+
+	requests := make(chan notify.RequestSpec, 2)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		defer func() {
-			_ = r.Body.Close()
-		}()
-
-		data, err := io.ReadAll(r.Body)
-		if err != nil {
-			t.Errorf("read body: %v", err)
-			w.WriteHeader(http.StatusInternalServerError)
-			return
-		}
-
-		var payload map[string]any
-		if err := json.Unmarshal(data, &payload); err != nil {
-			t.Errorf("decode json: %v", err)
-			w.WriteHeader(http.StatusBadRequest)
-			return
-		}
-		requests <- payload
+		requests <- captureRequestSpec(t, r)
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer server.Close()
 
+	targetURL := "json://" + server.Listener.Addr().String() + "/notify?format=html"
+	body := "_hello_"
+
+	pyStdout, pyStderr, err := testutil.RunApprise(t, "-i", "markdown", "-b", body, targetURL)
+	if err != nil {
+		t.Fatalf("python apprise failed: %v stdout=%s stderr=%s", err, pyStdout, pyStderr)
+	}
+	pythonRequests := readRequestSpecs(t, requests)
+
 	if err := Send(
-		[]string{"json://" + server.Listener.Addr().String() + "/notify?format=html"},
-		"_hello_",
+		[]string{targetURL},
+		body,
 		WithInputFormat("markdown"),
 	); err != nil {
 		t.Fatalf("send: %v", err)
 	}
+	goRequests := readRequestSpecs(t, requests)
 
-	payload := readPayload(t, requests)
-	if got := payload["message"]; got != "<p><em>hello</em></p>\n" {
-		t.Fatalf("message = %q, want converted html", got)
-	}
+	testutil.AssertRequestSpecSequenceMatches(t, pythonRequests, goRequests)
 }
 
 func TestAppriseSendNoTargets(t *testing.T) {
@@ -85,14 +77,45 @@ func TestAppriseAddRejectsUnsupportedSchema(t *testing.T) {
 	}
 }
 
-func readPayload(t *testing.T, requests <-chan map[string]any) map[string]any {
+func captureRequestSpec(t *testing.T, r *http.Request) notify.RequestSpec {
+	t.Helper()
+	defer r.Body.Close()
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		t.Fatalf("read request body: %v", err)
+	}
+	headers := map[string]string{}
+	for key, values := range r.Header {
+		headers[key] = strings.Join(values, ",")
+	}
+
+	return notify.RequestSpec{
+		Method:  r.Method,
+		URL:     "http://" + r.Host + r.URL.RequestURI(),
+		Headers: headers,
+		Body:    string(body),
+	}
+}
+
+func readRequestSpecs(t *testing.T, requests <-chan notify.RequestSpec) []notify.RequestSpec {
 	t.Helper()
 
+	specs := []notify.RequestSpec{}
 	select {
-	case payload := <-requests:
-		return payload
+	case spec := <-requests:
+		specs = append(specs, spec)
 	case <-time.After(time.Second):
 		t.Fatalf("timed out waiting for request")
 		return nil
+	}
+
+	for {
+		select {
+		case spec := <-requests:
+			specs = append(specs, spec)
+		default:
+			return specs
+		}
 	}
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -34,6 +34,12 @@ type parsedConfig struct {
 	Groups map[string][]string
 }
 
+type textConfigLine struct {
+	URLs      []taggedURL
+	Groups    []string
+	GroupTags []string
+}
+
 func loadTaggedURLs(configPaths []string) []taggedURL {
 	urls := []taggedURL{}
 	for _, path := range configPaths {
@@ -72,21 +78,11 @@ func parseTextConfig(raw string) parsedConfig {
 
 	scanner := bufio.NewScanner(strings.NewReader(raw))
 	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
+		parsed := parseTextConfigLine(scanner.Text())
+		for _, group := range parsed.Groups {
+			cfg.Groups[group] = append(cfg.Groups[group], parsed.GroupTags...)
 		}
-
-		if groups, tags, ok := parseGroupAssignment(line); ok {
-			for _, group := range groups {
-				cfg.Groups[group] = append(cfg.Groups[group], tags...)
-			}
-			continue
-		}
-
-		if parsed := parseTaggedLine(line); len(parsed) > 0 {
-			cfg.URLs = append(cfg.URLs, parsed...)
-		}
+		cfg.URLs = append(cfg.URLs, parsed.URLs...)
 	}
 	if err := scanner.Err(); err != nil {
 		return cfg
@@ -111,6 +107,22 @@ func parseYAMLConfig(data []byte) parsedConfig {
 		Groups: parseYAMLGroups(rootMap["groups"]),
 	}
 	return cfg
+}
+
+func parseTextConfigLine(line string) textConfigLine {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+		return textConfigLine{}
+	}
+
+	if groups, tags, ok := parseGroupAssignment(line); ok {
+		return textConfigLine{Groups: groups, GroupTags: tags}
+	}
+	if strings.Contains(line, ":") && !urlSchemeRe.MatchString(line) {
+		return textConfigLine{}
+	}
+
+	return textConfigLine{URLs: parseTaggedLine(line)}
 }
 
 func parseTaggedLine(line string) []taggedURL {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,12 +1,14 @@
 package cli
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/unraid/apprise-go/internal/testutil"
 	"gopkg.in/yaml.v3"
 )
 
@@ -252,6 +254,35 @@ mygrouptag=mytagA
 	}
 }
 
+func TestResolveNotifyURLsDoesNotTreatColonTextAsGroupSyntax(t *testing.T) {
+	configPath := writeConfig(t, "apprise.conf", `
+# Groups
+now: now_pers
+now_pers: my_now_pers
+
+# Telegram: Personal
+my_now_pers=tgram://123456:abcdef/7890/?format=markdown&mdv=v1
+`)
+
+	for _, tag := range []string{"now_pers", "now"} {
+		opts := &cliOptions{
+			configPaths: []string{configPath},
+			tags:        []string{tag},
+		}
+		if tagged := resolveNotifyURLs(opts, nil, nil); len(tagged) != 0 {
+			t.Fatalf("expected unsupported colon group %q not to match, got %#v", tag, tagged)
+		}
+	}
+
+	opts := &cliOptions{
+		configPaths: []string{configPath},
+		tags:        []string{"my_now_pers"},
+	}
+	assertTaggedURLs(t, resolveNotifyURLs(opts, nil, nil), []taggedURL{
+		{URL: "tgram://123456:abcdef/7890/?format=markdown&mdv=v1", Tags: []string{"my_now_pers"}},
+	})
+}
+
 func TestResolveNotifyURLsFiltersYAMLGroupTags(t *testing.T) {
 	configPath := writeConfig(t, "apprise.yaml", `
 version: 1
@@ -308,6 +339,89 @@ urls:
 			assertTaggedURLs(t, tagged, []taggedURL{
 				{URL: "tgram://123456:abcdef/7890/", Tags: []string{"grouptag", "mytag"}},
 			})
+		})
+	}
+}
+
+func TestResolveNotifyURLsMatchesIssue47NestedYAMLGroupRepro(t *testing.T) {
+	configPath := writeConfig(t, "apprise.yaml", `
+version: 1
+groups:
+  now: now_pers
+  now_pers: my_now_pers
+urls:
+  - tgram://123456:abcdef/7890/?format=markdown&mdv=v1:
+      tag: my_now_pers
+`)
+
+	for _, tag := range []string{"my_now_pers", "now_pers", "now"} {
+		t.Run(tag, func(t *testing.T) {
+			opts := &cliOptions{
+				configPaths: []string{configPath},
+				tags:        []string{tag},
+			}
+
+			tagged := resolveNotifyURLs(opts, nil, nil)
+
+			assertTaggedURLs(t, tagged, []taggedURL{
+				{
+					URL:  "tgram://123456:abcdef/7890/?format=markdown&mdv=v1",
+					Tags: []string{"my_now_pers", "now", "now_pers"},
+				},
+			})
+		})
+	}
+}
+
+func TestResolveNotifyURLsMatchesPythonNestedGroupParity(t *testing.T) {
+	testutil.RequirePythonApprise(t)
+
+	for _, tc := range []struct {
+		name     string
+		filename string
+		content  string
+	}{
+		{
+			name:     "text equals nested groups",
+			filename: "apprise.conf",
+			content: `
+now=now_pers
+now_pers=my_now_pers
+my_now_pers=json://localhost/one
+`,
+		},
+		{
+			name:     "yaml nested groups",
+			filename: "apprise.yaml",
+			content: `
+version: 1
+groups:
+  now: now_pers
+  now_pers: my_now_pers
+urls:
+  - json://localhost/one:
+      tag: my_now_pers
+`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			configPath := writeConfig(t, tc.filename, tc.content)
+			tags := []string{"my_now_pers", "now_pers", "now"}
+			pythonTags := pythonAppriseResolvedTags(t, configPath, tags)
+
+			for _, tag := range tags {
+				opts := &cliOptions{
+					configPaths: []string{configPath},
+					tags:        []string{tag},
+				}
+				tagged := resolveNotifyURLs(opts, nil, nil)
+				if len(tagged) != len(pythonTags[tag]) {
+					t.Fatalf("tag %q URL count mismatch: go=%d python=%d", tag, len(tagged), len(pythonTags[tag]))
+				}
+				for idx := range tagged {
+					assertStringSlices(t, tagged[idx].Tags, pythonTags[tag][idx])
+				}
+			}
 		})
 	}
 }
@@ -398,6 +512,33 @@ func TestParseTaggedLineHandlesMultipleURLsAndNoURL(t *testing.T) {
 	}
 }
 
+func TestParseTextConfigLineSeparatesConfigGrammar(t *testing.T) {
+	for _, line := range []string{"", " # comment", "; comment"} {
+		if got := parseTextConfigLine(line); len(got.URLs) != 0 || len(got.Groups) != 0 || len(got.GroupTags) != 0 {
+			t.Fatalf("expected empty parsed line for %q, got %#v", line, got)
+		}
+	}
+
+	assertTaggedURLs(t, parseTextConfigLine("tagA=json://localhost/one").URLs, []taggedURL{
+		{URL: "json://localhost/one", Tags: []string{"taga"}},
+	})
+
+	grouped := parseTextConfigLine("groupA = tagA")
+	assertStringSlices(t, grouped.Groups, []string{"groupa"})
+	assertStringSlices(t, grouped.GroupTags, []string{"taga"})
+	if len(grouped.URLs) != 0 {
+		t.Fatalf("expected no URLs for group assignment, got %#v", grouped.URLs)
+	}
+
+	if got := parseTextConfigLine("groupA: tagA"); len(got.URLs) != 0 || len(got.Groups) != 0 || len(got.GroupTags) != 0 {
+		t.Fatalf("expected unsupported colon assignment to be ignored, got %#v", got)
+	}
+
+	assertTaggedURLs(t, parseTextConfigLine("json://localhost/path?format=full").URLs, []taggedURL{
+		{URL: "json://localhost/path?format=full"},
+	})
+}
+
 func TestParseGroupAssignmentValidation(t *testing.T) {
 	groups, tags, ok := parseGroupAssignment("groupA, groupB = tagA tagB")
 	if !ok {
@@ -406,7 +547,7 @@ func TestParseGroupAssignmentValidation(t *testing.T) {
 	assertStringSlices(t, groups, []string{"groupa", "groupb"})
 	assertStringSlices(t, tags, []string{"taga", "tagb"})
 
-	for _, line := range []string{"no equals", "=tag", "group=", "json://localhost/a=tag", "group=json://localhost/a"} {
+	for _, line := range []string{"no equals", "groupC: tagC", "=tag", "group=", "json://localhost/a=tag", "group=json://localhost/a"} {
 		if _, _, ok := parseGroupAssignment(line); ok {
 			t.Fatalf("expected invalid assignment for %q", line)
 		}
@@ -560,6 +701,37 @@ func writeConfig(t *testing.T, name, content string) string {
 		t.Fatalf("write config: %v", err)
 	}
 	return path
+}
+
+func pythonAppriseResolvedTags(t *testing.T, configPath string, tags []string) map[string][][]string {
+	t.Helper()
+
+	script := `
+import apprise
+import json
+import sys
+
+config_path = sys.argv[1]
+tags = sys.argv[2:]
+config = apprise.AppriseConfig(paths=config_path)
+app = apprise.Apprise()
+app.add(config)
+result = {}
+for tag in tags:
+    result[tag] = [sorted(server.tags) for server in app.find(tag)]
+print(json.dumps(result, sort_keys=True))
+`
+	args := append([]string{"-c", script, configPath}, tags...)
+	stdout, stderr, err := testutil.RunCommand(t, testutil.PythonPath(t), args...)
+	if err != nil {
+		t.Fatalf("python apprise config resolution failed: %v stdout=%s stderr=%s", err, strings.TrimSpace(stdout), strings.TrimSpace(stderr))
+	}
+
+	var resolved map[string][][]string
+	if err := json.Unmarshal([]byte(stdout), &resolved); err != nil {
+		t.Fatalf("decode python apprise config resolution: %v stdout=%s", err, stdout)
+	}
+	return resolved
 }
 
 func mustYAMLValue(t *testing.T, raw string) any {

--- a/internal/notify/format_convert.go
+++ b/internal/notify/format_convert.go
@@ -66,7 +66,7 @@ func markdownToHTML(content string) string {
 	renderer := html.NewRenderer(html.RendererOptions{
 		Flags: html.CommonFlags,
 	})
-	return string(markdown.ToHTML([]byte(content), mdParser, renderer))
+	return strings.TrimSuffix(string(markdown.ToHTML([]byte(content), mdParser, renderer)), "\n")
 }
 
 func ConvertMessageFormat(content, inputFormat, outputFormat string) (string, error) {

--- a/internal/notify/schema_asset.go
+++ b/internal/notify/schema_asset.go
@@ -40,9 +40,14 @@ func computeImagePathMask() string {
 	}
 
 	if moduleRoot, ok := findModuleRoot(); ok {
-		candidateRoot := filepath.Join(moduleRoot, "..", "apprise", "apprise")
-		if dirExists(filepath.Join(candidateRoot, "assets")) {
-			return joinAssetMask(candidateRoot)
+		for _, candidateRoot := range []string{
+			filepath.Join(moduleRoot, "..", "apprise"),
+			filepath.Join(moduleRoot, "..", "apprise", "apprise"),
+			filepath.Join(moduleRoot, "..", "apprise", "apprise", "apprise"),
+		} {
+			if dirExists(filepath.Join(candidateRoot, "assets")) {
+				return joinAssetMask(candidateRoot)
+			}
 		}
 	}
 

--- a/internal/notify/telegram.go
+++ b/internal/notify/telegram.go
@@ -303,7 +303,7 @@ func parseOptionalIntValue(raw string) *int {
 
 func (t *TelegramTarget) parseMode() string {
 	switch t.notifyFormat {
-	case "html":
+	case "html", "text":
 		return "HTML"
 	case "markdown":
 		return t.markdownMode
@@ -317,7 +317,7 @@ func telegramMarkdownMode(raw string) string {
 	case "v2", "markdownv2":
 		return "MarkdownV2"
 	default:
-		return "Markdown"
+		return "MARKDOWN"
 	}
 }
 

--- a/internal/notify/telegram_format_test.go
+++ b/internal/notify/telegram_format_test.go
@@ -17,7 +17,7 @@ func TestTelegramMarkdownFormatSetsMarkdownParseMode(t *testing.T) {
 	assertTelegramFormatParity(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v1", "_This is Italics Text_", "", "markdown")
 }
 
-func TestTelegramTextFormatOmitsParseMode(t *testing.T) {
+func TestTelegramTextFormatUsesHTMLParseMode(t *testing.T) {
 	assertTelegramFormatParity(t, "tgram://123456:abcdef/7890/?format=text", "<b>plain</b>", "Title", "text")
 }
 


### PR DESCRIPTION
## Summary

- Harden text config parsing so Apprise `.conf` syntax stays strict while YAML group syntax remains YAML-only.
- Add Python-backed parity coverage for nested tag groups in supported text and YAML config forms.
- Fix related parity regressions in Markdown HTML conversion, Telegram parse modes, and schema asset path resolution.

## Root Cause

The config tag tests covered a simplified single-level group case and local expectations, but did not compare nested group resolution against Python Apprise. That let YAML/nested group behavior and unsupported `.conf` colon syntax blur together.

## Validation

- `env GOCACHE=/Users/elibosley/Code/apprise-go/.gocache go test ./...`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Trim trailing newline from converted HTML.
  * Better asset discovery across installation locations.
  * Telegram: treat text format as HTML parse mode and normalize markdown v1 mode.

* **New Features**
  * More robust text-config parsing that ignores blank/comment/semicolon lines and avoids treating colon-containing URLs as group syntax.

* **Tests**
  * Expanded config and nested-group tests, added Python parity checks and improved end-to-end request/format conversion comparisons.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/apprise-go/pull/55?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->