### PR TITLE
fix: telegram formatting and yaml config validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ apprise --details
 apprise --storage-path /path/to/config -b "Using saved config"
 ```
 
+### Configuration Files
+
+apprise-go supports Apprise-style TEXT and YAML configuration files. YAML tagged
+URLs should use the upstream mapping form where the URL has a trailing colon:
+
+```yaml
+version: 1
+groups:
+  now: my_now_pers
+urls:
+  - tgram://token_id/chat_id/?format=markdown&mdv=v1:
+      tag: my_now_pers
+```
+
+Do not put `tag` under a bare scalar URL; that is not valid YAML and will not be
+loaded as a tagged Apprise URL.
+
 ## Releases
 
 ### Latest Release

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -218,7 +218,7 @@ func Run(args []string, stdout, stderr io.Writer) int {
 			continue
 		}
 
-		sendBody, err := notify.ConvertMessageFormat(body, opts.inputFormat, parsed.Query["format"])
+		sendBody, err := notify.ConvertMessageFormatForTarget(parsed, body, opts.inputFormat)
 		if err != nil {
 			fmt.Fprintln(stderr, err)
 			failed = true

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -88,6 +89,29 @@ func TestRunSendsHTMLInputToTelegramHTMLTarget(t *testing.T) {
 
 func TestRunSendsMarkdownInputToTelegramMarkdownTarget(t *testing.T) {
 	assertRunHTTPRequestParity(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v1", "_This is Italics Text_", "", "markdown")
+}
+
+func TestRunConvertsStandardMarkdownInputForTelegramMarkdownTarget(t *testing.T) {
+	goSpecs := testutil.CaptureGoRequests(t, func() error {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		code := Run([]string{"-i", "markdown", "-b", "~~Strike~~ **Bold** _Italics_ Text", "tgram://123456:abcdef/7890/?format=markdown&mdv=v2"}, stdout, stderr)
+		if code != 0 {
+			return fmt.Errorf("Run failed with code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		}
+		return nil
+	})
+	if len(goSpecs) != 1 {
+		t.Fatalf("expected one request, got %d", len(goSpecs))
+	}
+
+	payload := decodeJSONPayload(t, goSpecs[0].Body)
+	if payload["parse_mode"] != "MarkdownV2" {
+		t.Fatalf("expected MarkdownV2 parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "~Strike~ *Bold* _Italics_ Text" {
+		t.Fatalf("expected Telegram markdown body, got %#v", payload["text"])
+	}
 }
 
 func TestRunConvertsMarkdownInputForMailtoHTMLTarget(t *testing.T) {
@@ -192,4 +216,13 @@ func assertRunHTTPRequestParity(t *testing.T, rawURL, body, title, inputFormat s
 	})
 
 	testutil.AssertRequestSpecSequenceMatches(t, pythonSpecs, goSpecs)
+}
+
+func decodeJSONPayload(t *testing.T, body string) map[string]any {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("decode json payload: %v", err)
+	}
+	return payload
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -62,7 +62,11 @@ func parseConfigFile(path string) []taggedURL {
 		return nil
 	}
 	if isYAMLConfigPath(path) {
-		if parsed := parseYAMLConfig(data); len(parsed.URLs) > 0 || len(parsed.Groups) > 0 {
+		parsed, validYAML := parseYAMLConfigWithStatus(data)
+		if !validYAML {
+			return nil
+		}
+		if len(parsed.URLs) > 0 || len(parsed.Groups) > 0 {
 			return applyTagGroups(parsed.URLs, parsed.Groups)
 		}
 	}
@@ -91,14 +95,19 @@ func parseTextConfig(raw string) parsedConfig {
 }
 
 func parseYAMLConfig(data []byte) parsedConfig {
+	parsed, _ := parseYAMLConfigWithStatus(data)
+	return parsed
+}
+
+func parseYAMLConfigWithStatus(data []byte) (parsedConfig, bool) {
 	var root any
 	if err := yaml.Unmarshal(data, &root); err != nil {
-		return parsedConfig{URLs: []taggedURL{}, Groups: map[string][]string{}}
+		return parsedConfig{URLs: []taggedURL{}, Groups: map[string][]string{}}, false
 	}
 
 	rootMap, ok := asStringMap(root)
 	if !ok {
-		return parsedConfig{URLs: []taggedURL{}, Groups: map[string][]string{}}
+		return parsedConfig{URLs: []taggedURL{}, Groups: map[string][]string{}}, true
 	}
 
 	globalTags := parseYAMLTags(rootMap)
@@ -106,7 +115,7 @@ func parseYAMLConfig(data []byte) parsedConfig {
 		URLs:   parseYAMLURLs(rootMap["urls"], globalTags),
 		Groups: parseYAMLGroups(rootMap["groups"]),
 	}
-	return cfg
+	return cfg, true
 }
 
 func parseTextConfigLine(line string) textConfigLine {

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -34,6 +34,8 @@ func TestParseConfigFileTextFallbackForYAMLWithoutStructuredConfig(t *testing.T)
 }
 
 func TestParseConfigFileDoesNotTextFallbackForInvalidYAML(t *testing.T) {
+	testutil.RequirePythonApprise(t)
+
 	configPath := writeConfig(t, "apprise.yaml", `
 version: 1
 groups:
@@ -45,6 +47,11 @@ urls:
 
 	if tagged := parseConfigFile(configPath); len(tagged) != 0 {
 		t.Fatalf("expected invalid YAML not to fall back to text parsing, got %#v", tagged)
+	}
+
+	pythonTags := pythonAppriseResolvedTags(t, configPath, []string{"my_now_pers"})
+	if got := pythonTags["my_now_pers"]; len(got) != 0 {
+		t.Fatalf("expected python apprise to resolve no URLs for invalid YAML, got %#v", got)
 	}
 }
 

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -33,6 +33,21 @@ func TestParseConfigFileTextFallbackForYAMLWithoutStructuredConfig(t *testing.T)
 	assertTaggedURLs(t, tagged, []taggedURL{{URL: "json://localhost/one", Tags: []string{"tag"}}})
 }
 
+func TestParseConfigFileDoesNotTextFallbackForInvalidYAML(t *testing.T) {
+	configPath := writeConfig(t, "apprise.yaml", `
+version: 1
+groups:
+  now: my_now_pers
+urls:
+  - json://localhost/one
+      tag: my_now_pers
+`)
+
+	if tagged := parseConfigFile(configPath); len(tagged) != 0 {
+		t.Fatalf("expected invalid YAML not to fall back to text parsing, got %#v", tagged)
+	}
+}
+
 func TestParseConfigFileMissingFile(t *testing.T) {
 	if tagged := parseConfigFile(filepath.Join(t.TempDir(), "missing.conf")); tagged != nil {
 		t.Fatalf("expected nil for missing file, got %#v", tagged)

--- a/internal/notify/target.go
+++ b/internal/notify/target.go
@@ -42,7 +42,7 @@ func SendTargetURL(rawURL, body, title, inputFormat string, notifyType NotifyTyp
 		return err
 	}
 
-	sendBody, err := ConvertMessageFormat(body, inputFormat, parsed.Query["format"])
+	sendBody, err := ConvertMessageFormatForTarget(parsed, body, inputFormat)
 	if err != nil {
 		return err
 	}

--- a/internal/notify/target_format_convert.go
+++ b/internal/notify/target_format_convert.go
@@ -1,0 +1,15 @@
+package notify
+
+import "strings"
+
+func ConvertMessageFormatForTarget(parsed *ParsedURL, content, inputFormat string) (string, error) {
+	if parsed != nil && strings.EqualFold(parsed.Scheme, "tgram") {
+		return convertTelegramMessageFormat(content, inputFormat, parsed.Query["format"], parsed.Query["mdv"])
+	}
+
+	outputFormat := ""
+	if parsed != nil {
+		outputFormat = parsed.Query["format"]
+	}
+	return ConvertMessageFormat(content, inputFormat, outputFormat)
+}

--- a/internal/notify/telegram_format_convert.go
+++ b/internal/notify/telegram_format_convert.go
@@ -1,0 +1,274 @@
+package notify
+
+import (
+	"fmt"
+	"html"
+	"strings"
+
+	nethtml "golang.org/x/net/html"
+)
+
+var telegramHTMLBlockTags = map[string]struct{}{
+	"blockquote": {},
+	"div":        {},
+	"h1":         {},
+	"h2":         {},
+	"h3":         {},
+	"h4":         {},
+	"h5":         {},
+	"h6":         {},
+	"li":         {},
+	"p":          {},
+	"pre":        {},
+}
+
+func convertTelegramMessageFormat(content, inputFormat, outputFormat, markdownVersion string) (string, error) {
+	input := normalizeNotifyFormat(inputFormat)
+	output := normalizeNotifyFormat(outputFormat)
+	if input == "" {
+		input = "text"
+	}
+	if output == "" {
+		output = "html"
+	}
+	if !isSupportedNotifyFormat(input) {
+		return "", fmt.Errorf("invalid input format: %s", inputFormat)
+	}
+	if !isSupportedNotifyFormat(output) {
+		return "", fmt.Errorf("invalid output format: %s", outputFormat)
+	}
+
+	switch output {
+	case "html":
+		switch input {
+		case "markdown":
+			return telegramHTMLFromHTML(markdownToHTML(content)), nil
+		case "html":
+			return telegramHTMLFromHTML(content), nil
+		case "text":
+			return html.EscapeString(content), nil
+		}
+	case "markdown":
+		mode := telegramMarkdownMode(markdownVersion)
+		switch input {
+		case "markdown":
+			return telegramMarkdownFromHTML(markdownToHTML(content), mode), nil
+		case "html":
+			return telegramMarkdownFromHTML(content, mode), nil
+		case "text":
+			return escapeTelegramMarkdownText(content, mode), nil
+		}
+	case "text":
+		return ConvertMessageFormat(content, input, output)
+	}
+
+	return content, nil
+}
+
+func telegramHTMLFromHTML(content string) string {
+	if strings.TrimSpace(content) == "" {
+		return ""
+	}
+	root, err := nethtml.Parse(strings.NewReader(content))
+	if err != nil {
+		return html.EscapeString(content)
+	}
+
+	var out strings.Builder
+	renderTelegramHTMLNode(&out, root)
+	return strings.Trim(out.String(), "\n")
+}
+
+func renderTelegramHTMLNode(out *strings.Builder, node *nethtml.Node) {
+	if node.Type == nethtml.TextNode {
+		out.WriteString(html.EscapeString(node.Data))
+		return
+	}
+	if node.Type != nethtml.ElementNode {
+		renderTelegramHTMLChildren(out, node)
+		return
+	}
+
+	tag := strings.ToLower(node.Data)
+	if _, ok := telegramHTMLBlockTags[tag]; ok && out.Len() > 0 {
+		ensureLineBreak(out)
+	}
+
+	switch tag {
+	case "a":
+		href := htmlAttr(node, "href")
+		if href == "" {
+			renderTelegramHTMLChildren(out, node)
+			break
+		}
+		out.WriteString(`<a href="`)
+		out.WriteString(html.EscapeString(href))
+		out.WriteString(`">`)
+		renderTelegramHTMLChildren(out, node)
+		out.WriteString("</a>")
+	case "b", "strong":
+		out.WriteString("<b>")
+		renderTelegramHTMLChildren(out, node)
+		out.WriteString("</b>")
+	case "blockquote":
+		out.WriteString("<blockquote>")
+		renderTelegramHTMLChildren(out, node)
+		out.WriteString("</blockquote>")
+	case "br":
+		ensureLineBreak(out)
+	case "code":
+		out.WriteString("<code>")
+		renderTelegramHTMLChildren(out, node)
+		out.WriteString("</code>")
+	case "del", "s", "strike":
+		out.WriteString("<s>")
+		renderTelegramHTMLChildren(out, node)
+		out.WriteString("</s>")
+	case "em", "i":
+		out.WriteString("<i>")
+		renderTelegramHTMLChildren(out, node)
+		out.WriteString("</i>")
+	case "pre":
+		out.WriteString("<pre>")
+		renderTelegramHTMLChildren(out, node)
+		out.WriteString("</pre>")
+	case "u", "ins":
+		out.WriteString("<u>")
+		renderTelegramHTMLChildren(out, node)
+		out.WriteString("</u>")
+	default:
+		renderTelegramHTMLChildren(out, node)
+	}
+
+	if _, ok := telegramHTMLBlockTags[tag]; ok {
+		ensureLineBreak(out)
+	}
+}
+
+func renderTelegramHTMLChildren(out *strings.Builder, node *nethtml.Node) {
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		renderTelegramHTMLNode(out, child)
+	}
+}
+
+func telegramMarkdownFromHTML(content, markdownMode string) string {
+	if strings.TrimSpace(content) == "" {
+		return ""
+	}
+	root, err := nethtml.Parse(strings.NewReader(content))
+	if err != nil {
+		return escapeTelegramMarkdownText(content, markdownMode)
+	}
+
+	var out strings.Builder
+	renderTelegramMarkdownNode(&out, root, markdownMode)
+	return strings.Trim(out.String(), "\n")
+}
+
+func renderTelegramMarkdownNode(out *strings.Builder, node *nethtml.Node, markdownMode string) {
+	if node.Type == nethtml.TextNode {
+		out.WriteString(escapeTelegramMarkdownText(node.Data, markdownMode))
+		return
+	}
+	if node.Type != nethtml.ElementNode {
+		renderTelegramMarkdownChildren(out, node, markdownMode)
+		return
+	}
+
+	tag := strings.ToLower(node.Data)
+	if _, ok := telegramHTMLBlockTags[tag]; ok && out.Len() > 0 {
+		ensureLineBreak(out)
+	}
+
+	switch tag {
+	case "b", "strong":
+		out.WriteString("*")
+		renderTelegramMarkdownChildren(out, node, markdownMode)
+		out.WriteString("*")
+	case "br":
+		ensureLineBreak(out)
+	case "code":
+		out.WriteString("`")
+		renderTelegramMarkdownChildren(out, node, markdownMode)
+		out.WriteString("`")
+	case "del", "s", "strike":
+		out.WriteString("~")
+		renderTelegramMarkdownChildren(out, node, markdownMode)
+		out.WriteString("~")
+	case "em", "i":
+		out.WriteString("_")
+		renderTelegramMarkdownChildren(out, node, markdownMode)
+		out.WriteString("_")
+	case "pre":
+		out.WriteString("```")
+		renderTelegramMarkdownChildren(out, node, markdownMode)
+		out.WriteString("```")
+	default:
+		renderTelegramMarkdownChildren(out, node, markdownMode)
+	}
+
+	if _, ok := telegramHTMLBlockTags[tag]; ok {
+		ensureLineBreak(out)
+	}
+}
+
+func renderTelegramMarkdownChildren(out *strings.Builder, node *nethtml.Node, markdownMode string) {
+	for child := node.FirstChild; child != nil; child = child.NextSibling {
+		renderTelegramMarkdownNode(out, child, markdownMode)
+	}
+}
+
+func escapeTelegramMarkdownText(value, markdownMode string) string {
+	if markdownMode == "MarkdownV2" {
+		replacer := strings.NewReplacer(
+			"\\", "\\\\",
+			"_", "\\_",
+			"*", "\\*",
+			"[", "\\[",
+			"]", "\\]",
+			"(", "\\(",
+			")", "\\)",
+			"~", "\\~",
+			"`", "\\`",
+			">", "\\>",
+			"#", "\\#",
+			"+", "\\+",
+			"-", "\\-",
+			"=", "\\=",
+			"|", "\\|",
+			"{", "\\{",
+			"}", "\\}",
+			".", "\\.",
+			"!", "\\!",
+		)
+		return replacer.Replace(value)
+	}
+
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		"*", "\\*",
+		"_", "\\_",
+		"`", "\\`",
+		"[", "\\[",
+	)
+	return replacer.Replace(value)
+}
+
+func htmlAttr(node *nethtml.Node, key string) string {
+	for _, attr := range node.Attr {
+		if strings.EqualFold(attr.Key, key) {
+			return attr.Val
+		}
+	}
+	return ""
+}
+
+func ensureLineBreak(out *strings.Builder) {
+	if out.Len() == 0 {
+		return
+	}
+	value := out.String()
+	if value[len(value)-1] != '\n' {
+		out.WriteByte('\n')
+	}
+}

--- a/internal/notify/telegram_format_convert.go
+++ b/internal/notify/telegram_format_convert.go
@@ -161,17 +161,21 @@ func telegramMarkdownFromHTML(content, markdownMode string) string {
 	}
 
 	var out strings.Builder
-	renderTelegramMarkdownNode(&out, root, markdownMode)
+	renderTelegramMarkdownNode(&out, root, markdownMode, false)
 	return strings.Trim(out.String(), "\n")
 }
 
-func renderTelegramMarkdownNode(out *strings.Builder, node *nethtml.Node, markdownMode string) {
+func renderTelegramMarkdownNode(out *strings.Builder, node *nethtml.Node, markdownMode string, inCode bool) {
 	if node.Type == nethtml.TextNode {
+		if inCode {
+			out.WriteString(escapeTelegramMarkdownCodeText(node.Data))
+			return
+		}
 		out.WriteString(escapeTelegramMarkdownText(node.Data, markdownMode))
 		return
 	}
 	if node.Type != nethtml.ElementNode {
-		renderTelegramMarkdownChildren(out, node, markdownMode)
+		renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
 		return
 	}
 
@@ -181,30 +185,41 @@ func renderTelegramMarkdownNode(out *strings.Builder, node *nethtml.Node, markdo
 	}
 
 	switch tag {
+	case "a":
+		href := htmlAttr(node, "href")
+		if href == "" {
+			renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
+			break
+		}
+		out.WriteString("[")
+		renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
+		out.WriteString("](")
+		out.WriteString(escapeTelegramMarkdownLink(href, markdownMode))
+		out.WriteString(")")
 	case "b", "strong":
 		out.WriteString("*")
-		renderTelegramMarkdownChildren(out, node, markdownMode)
+		renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
 		out.WriteString("*")
 	case "br":
 		ensureLineBreak(out)
 	case "code":
 		out.WriteString("`")
-		renderTelegramMarkdownChildren(out, node, markdownMode)
+		renderTelegramMarkdownChildren(out, node, markdownMode, true)
 		out.WriteString("`")
 	case "del", "s", "strike":
 		out.WriteString("~")
-		renderTelegramMarkdownChildren(out, node, markdownMode)
+		renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
 		out.WriteString("~")
 	case "em", "i":
 		out.WriteString("_")
-		renderTelegramMarkdownChildren(out, node, markdownMode)
+		renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
 		out.WriteString("_")
 	case "pre":
 		out.WriteString("```")
-		renderTelegramMarkdownChildren(out, node, markdownMode)
+		renderTelegramMarkdownChildren(out, node, markdownMode, true)
 		out.WriteString("```")
 	default:
-		renderTelegramMarkdownChildren(out, node, markdownMode)
+		renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
 	}
 
 	if _, ok := telegramHTMLBlockTags[tag]; ok {
@@ -212,10 +227,29 @@ func renderTelegramMarkdownNode(out *strings.Builder, node *nethtml.Node, markdo
 	}
 }
 
-func renderTelegramMarkdownChildren(out *strings.Builder, node *nethtml.Node, markdownMode string) {
+func renderTelegramMarkdownChildren(out *strings.Builder, node *nethtml.Node, markdownMode string, inCode bool) {
 	for child := node.FirstChild; child != nil; child = child.NextSibling {
-		renderTelegramMarkdownNode(out, child, markdownMode)
+		renderTelegramMarkdownNode(out, child, markdownMode, inCode)
 	}
+}
+
+func escapeTelegramMarkdownCodeText(value string) string {
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		"`", "\\`",
+	)
+	return replacer.Replace(value)
+}
+
+func escapeTelegramMarkdownLink(value, markdownMode string) string {
+	if markdownMode != "MarkdownV2" {
+		return value
+	}
+	replacer := strings.NewReplacer(
+		"\\", "\\\\",
+		")", "\\)",
+	)
+	return replacer.Replace(value)
 }
 
 func escapeTelegramMarkdownText(value, markdownMode string) string {

--- a/internal/notify/telegram_format_test.go
+++ b/internal/notify/telegram_format_test.go
@@ -17,6 +17,39 @@ func TestTelegramMarkdownFormatSetsMarkdownParseMode(t *testing.T) {
 	assertTelegramFormatParity(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v1", "_This is Italics Text_", "", "markdown")
 }
 
+func TestTelegramConvertsStandardMarkdownToMarkdownV1(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v1", "~~Strike~~ **Bold** _Italics_ Text", "", "markdown")
+
+	if payload["parse_mode"] != "MARKDOWN" {
+		t.Fatalf("expected MARKDOWN parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "~Strike~ *Bold* _Italics_ Text" {
+		t.Fatalf("expected Telegram markdown body, got %#v", payload["text"])
+	}
+}
+
+func TestTelegramConvertsStandardMarkdownToMarkdownV2(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v2", "~~Strike~~ **Bold** _Italics_ Text", "", "markdown")
+
+	if payload["parse_mode"] != "MarkdownV2" {
+		t.Fatalf("expected MarkdownV2 parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "~Strike~ *Bold* _Italics_ Text" {
+		t.Fatalf("expected Telegram markdown body, got %#v", payload["text"])
+	}
+}
+
+func TestTelegramConvertsStandardMarkdownToTelegramHTML(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=html", "~~Strike~~ **Bold** _Italics_ Text", "", "markdown")
+
+	if payload["parse_mode"] != "HTML" {
+		t.Fatalf("expected HTML parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "<s>Strike</s> <b>Bold</b> <i>Italics</i> Text" {
+		t.Fatalf("expected Telegram HTML body, got %#v", payload["text"])
+	}
+}
+
 func TestTelegramTextFormatUsesHTMLParseMode(t *testing.T) {
 	assertTelegramFormatParity(t, "tgram://123456:abcdef/7890/?format=text", "<b>plain</b>", "Title", "text")
 }
@@ -68,7 +101,7 @@ func assertTelegramFormatParity(t *testing.T, rawURL, body, title, bodyFormat st
 	if err != nil {
 		t.Fatalf("new telegram target: %v", err)
 	}
-	convertedBody, err := notify.ConvertMessageFormat(body, bodyFormat, parsed.Query["format"])
+	convertedBody, err := notify.ConvertMessageFormatForTarget(parsed, body, bodyFormat)
 	if err != nil {
 		t.Fatalf("convert body: %v", err)
 	}
@@ -77,6 +110,18 @@ func assertTelegramFormatParity(t *testing.T, rawURL, body, title, bodyFormat st
 	})
 
 	testutil.AssertRequestSpecSequenceMatches(t, pythonSpecs, goSpecs)
+}
+
+func captureTelegramPayload(t *testing.T, rawURL, body, title, bodyFormat string) map[string]any {
+	t.Helper()
+
+	specs := testutil.CaptureGoRequests(t, func() error {
+		return notify.SendTargetURL(rawURL, body, title, bodyFormat, notify.NotifyInfo)
+	})
+	if len(specs) != 1 {
+		t.Fatalf("expected one request, got %d", len(specs))
+	}
+	return decodeTelegramPayload(t, specs[0].Body)
 }
 
 func mustTelegramTarget(t *testing.T, raw string) *notify.TelegramTarget {

--- a/internal/notify/telegram_format_test.go
+++ b/internal/notify/telegram_format_test.go
@@ -50,6 +50,52 @@ func TestTelegramConvertsStandardMarkdownToTelegramHTML(t *testing.T) {
 	}
 }
 
+func TestTelegramMarkdownV2CodeEscapesOnlyBackticksAndBackslashes(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v2", "`if x > 0 { return path\\name }`", "", "markdown")
+
+	text, ok := payload["text"].(string)
+	if !ok {
+		t.Fatalf("expected text payload, got %#v", payload["text"])
+	}
+	if text != "`if x > 0 { return path\\\\name }`" {
+		t.Fatalf("expected minimally escaped code text, got %q", text)
+	}
+	for _, overescaped := range []string{`\>`, `\{`, `\}`} {
+		if strings.Contains(text, overescaped) {
+			t.Fatalf("expected code text not to contain overescaped fragment %q in %q", overescaped, text)
+		}
+	}
+}
+
+func TestTelegramMarkdownV2PreEscapesOnlyBackticksAndBackslashes(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v2", "<pre>if x > 0 { return path\\name }</pre>", "", "html")
+
+	text, ok := payload["text"].(string)
+	if !ok {
+		t.Fatalf("expected text payload, got %#v", payload["text"])
+	}
+	if text != "```if x > 0 { return path\\\\name }```" {
+		t.Fatalf("expected minimally escaped pre text, got %q", text)
+	}
+	for _, overescaped := range []string{`\>`, `\{`, `\}`} {
+		if strings.Contains(text, overescaped) {
+			t.Fatalf("expected pre text not to contain overescaped fragment %q in %q", overescaped, text)
+		}
+	}
+}
+
+func TestTelegramMarkdownV2PreservesLinks(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v2", `<a href="https://example.com/a)b\c">Docs</a>`, "", "html")
+
+	text, ok := payload["text"].(string)
+	if !ok {
+		t.Fatalf("expected text payload, got %#v", payload["text"])
+	}
+	if text != "[Docs](https://example.com/a\\)b\\\\c)" {
+		t.Fatalf("expected escaped Telegram markdown link, got %q", text)
+	}
+}
+
 func TestTelegramTextFormatUsesHTMLParseMode(t *testing.T) {
 	assertTelegramFormatParity(t, "tgram://123456:abcdef/7890/?format=text", "<b>plain</b>", "Title", "text")
 }


### PR DESCRIPTION
## Summary

- add Telegram-specific message format conversion for Markdown and HTML targets
- route CLI and library sends through target-aware format conversion
- reject syntactically invalid YAML config files instead of falling back to TEXT parsing
- document the supported tagged YAML shape and add regression coverage

## Why

Issue #48 showed that Telegram needs target-specific formatting: standard Markdown like `**Bold**` and `~~Strike~~` was being sent unchanged to Telegram Markdown, and generic Markdown-to-HTML produced tags Telegram rejects.

Issue #47's follow-up YAML example was invalid YAML, but apprise-go was too lenient: malformed `.yaml` files could fall back to TEXT parsing and accidentally extract an untagged URL. This makes invalid YAML fail closed and documents the correct upstream Apprise mapping form.

## Validation

- `go test ./internal/cli -run 'Config|YAML|Telegram'`
- `go test ./internal/notify -run 'Telegram|ConvertMessageFormat'`
- `go test ./...`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a Configuration Files section documenting Apprise-style TEXT/YAML configs with YAML guidance and examples.

* **New Features**
  * Telegram-specific message formatting supporting MarkdownV1, MarkdownV2, and Telegram-flavored HTML outputs.

* **Improvements**
  * Message conversion now selects target-specific output formats more accurately.
  * Config parsing no longer treats malformed YAML as valid text config (avoids unexpected fallbacks).

* **Tests**
  * Added tests validating Telegram format conversions and YAML parsing behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/apprise-go/pull/57?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->