### PR TITLE
fix: handle Telegram format conversion edge cases

### DIFF
--- a/.codex/coderabbit-fixes-wip.md
+++ b/.codex/coderabbit-fixes-wip.md
@@ -3,10 +3,10 @@
 ## Context
 
 - Repo: unraid/apprise-go
-- Branch: codex/fix-format-input-handling
-- PR: #50
-- PR URL: https://github.com/unraid/apprise-go/pull/50
-- Generated at: 2026-05-18T16:22:30Z
+- Branch: codex/telegram-formatting-followup
+- PR: #60
+- PR URL: https://github.com/unraid/apprise-go/pull/60
+- Generated at: 2026-05-21T00:36:00-04:00
 
 ## Inputs Pulled
 
@@ -18,48 +18,42 @@
 
 | Item ID | Type | File | Line | Summary | Status | Link | Evidence |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| CR-001 | thread | internal/notify/format_convert.go | 102 | HTML to Markdown currently uses HTML to text. Verified current code does this, but upstream Python Apprise has the same contract in conversion.py. | BLOCKED | https://github.com/unraid/apprise-go/pull/50#discussion_r3260222516 | Skipped to preserve Python parity. |
-| CR-002 | thread | internal/cli/cli_test.go | 154 | Convert added CLI Run Telegram/mailto tests from Go-only assertions to Python-vs-Go parity. | DONE | https://github.com/unraid/apprise-go/pull/50#discussion_r3260277570 | `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil` passed. |
-| CR-003 | thread | internal/notify/mailto_format_test.go | 31 | Use `net.JoinHostPort` when building mailto test authority. | DONE | https://github.com/unraid/apprise-go/pull/50#discussion_r3260357765 | `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil` passed. |
-| CR-004 | thread | internal/testutil/request_compare.go | 50 | Use `strings.EqualFold` for method comparison. | DONE | https://github.com/unraid/apprise-go/pull/50#discussion_r3260357786 | `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil` passed. |
-| RVW-001 | review-body | top-level | n/a | Earlier review body with six inline comments. | DONE | https://github.com/unraid/apprise-go/pull/50#pullrequestreview-4311662350 | Covered by prior commits plus CR-001 skip reason. |
-| RVW-002 | review-body | top-level | n/a | Review body requested Python parity for CLI Run Telegram/mailto format tests. | DONE | https://github.com/unraid/apprise-go/pull/50#pullrequestreview-4311723839 | Covered by CR-002. |
-| RVW-003 | review-body | internal/notify/telegram_format_test.go | 34-55 | Add Python parity to MarkdownV2 title escaping test. | BLOCKED | https://github.com/unraid/apprise-go/pull/50#pullrequestreview-4311819314 | Skipped: Python Apprise MarkdownV2 title/body blending differs from the Go-side hardening test, so adding this assertion would fail for an implementation-contract mismatch rather than guarding the reserved-character escaper. |
-| RVW-004 | review-body | internal/notify/mailto_format_test.go | 31 | Latest review-body mailto IPv6-safe authority item. | DONE | https://github.com/unraid/apprise-go/pull/50#pullrequestreview-4311819314 | Covered by CR-003. |
-| RVW-005 | review-body | internal/testutil/request_compare.go | 49-50 | Latest review-body `strings.EqualFold` item. | DONE | https://github.com/unraid/apprise-go/pull/50#pullrequestreview-4311819314 | Covered by CR-004. |
+| CR-001 | thread | internal/notify/format_convert_test.go | 168 | Add Python parity to the cross-target corpus test. | BLOCKED | https://github.com/unraid/apprise-go/pull/60#discussion_r3278534673 | Skipped: this corpus intentionally validates target format conversion behavior that fixes Telegram behavior beyond current Python Apprise. Adding Python request parity would lock in the upstream bug this PR is fixing. |
+| CR-002 | thread | internal/notify/telegram_format_test.go | 140 | Route new Telegram format tests through Python-vs-Go request-sequence parity. | BLOCKED | https://github.com/unraid/apprise-go/pull/60#discussion_r3278534678 | Skipped: these tests assert corrected Telegram parse payloads that current Python Apprise does not emit. |
+| CR-003 | thread | internal/notify/live/telegram_live_test.go | 101 | Add Python-apprise request parity to the live Telegram test. | BLOCKED | https://github.com/unraid/apprise-go/pull/60#discussion_r3278534680 | Skipped: live test purpose is Bot API acceptance of corrected Go-generated Telegram parse payloads, not matching upstream Python's currently broken formatting. |
+| CR-004 | thread | internal/notify/live/telegram_live_test.go | n/a | Require explicit destination for the live suite. | DONE | https://github.com/unraid/apprise-go/pull/60#discussion_r3278534682 | Addressed in `a3dd48f`; GraphQL reports thread resolved/outdated. |
+| RVW-001 | review-body | internal/notify/live/telegram_live_test.go | 140-149 | Redact bot token from live test transport error logs. | DONE | https://github.com/unraid/apprise-go/pull/60#pullrequestreview-4320292462 | Added redaction helper and regression test; targeted and full Go tests passed. |
 
 ## Execution Log
 
-### 1. Item: CR-002
-- Action: Replaced Go-only CLI Telegram HTTP assertions with `assertRunHTTPRequestParity`, using Python request capture and Go `Run(...)` under `CaptureGoRequests`. Replaced the mailto CLI test with Python CLI send plus Go `Run(...)` against the shared SMTP capture, comparing normalized SMTP output.
-- Validation: `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil`
+### 1. Item: CR-004
+- Action: Required `APPRISE_GO_TELEGRAM_CHAT_ID` for live validation and removed auto-discovery/bot-ID fallback.
+- Validation: `go test ./internal/notify/live -run TestTelegramLiveFormattingAgainstBotAPI -count=1 -v` with explicit live env passed.
 - Result: DONE
 
-### 2. Item: CR-003
-- Action: Changed mailto format test URL construction to use `net.JoinHostPort(host, port)`.
-- Validation: `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil`
+### 2. Item: CR-001
+- Action: Verified this asks for parity against Python Apprise behavior that does not include the corrected Telegram conversions under test.
+- Validation: Code/test review.
+- Result: BLOCKED; skipped because it conflicts with the bug fix goal.
+
+### 3. Item: CR-002
+- Action: Verified the requested parity would force the new Telegram unit tests back to current Python output.
+- Validation: Code/test review.
+- Result: BLOCKED; skipped because it conflicts with the bug fix goal.
+
+### 4. Item: CR-003
+- Action: Verified live validation is intentionally testing Bot API acceptance of Go-generated corrected payloads.
+- Validation: Code/test review.
+- Result: BLOCKED; skipped because Python parity is not the purpose of this live suite.
+
+### 5. Item: RVW-001
+- Action: Added token redaction before reporting request creation or transport errors.
+- Validation: `go test ./internal/notify/live -count=1`; `go test ./internal/notify ./internal/notify/live -run 'TestTelegram|TestTargetFormatConversionCorpusAcrossWorkflowTargets' -count=1`; live Bot API test with explicit env; `go test ./...`
 - Result: DONE
-
-### 3. Item: CR-004
-- Action: Replaced `strings.ToUpper(...) != strings.ToUpper(...)` with `!strings.EqualFold(...)`.
-- Validation: `go test -count=1 ./internal/cli ./internal/notify ./internal/testutil`
-- Result: DONE
-
-### 4. Item: CR-001
-- Action: Verified against `../apprise/apprise/apprise/conversion.py`; Python Apprise currently maps HTML to Markdown through `html_to_text`.
-- Validation: Code inspection.
-- Result: BLOCKED; skipped to preserve parity.
-
-### 5. Item: RVW-003
-- Action: Verified the request would compare Go MarkdownV2 title escaping against Python's different Markdown title/body blending behavior.
-- Validation: Code inspection of `../apprise/apprise/apprise/plugins/base.py` and `../apprise/apprise/apprise/plugins/telegram.py`.
-- Result: BLOCKED; skipped as not a valid parity assertion against current upstream behavior.
 
 ## Final Checks
 
 - [x] Queue reviewed: no `TODO` left
 - [x] Remaining `BLOCKED` items documented with reason
-- [x] Re-pulled CodeRabbit threads and reviews
-- [x] No unhandled top-level review-body comment remains
-
-Re-pull result: one unresolved CodeRabbit inline thread remains (`CR-001`) and is intentionally `BLOCKED` because the requested HTML to Markdown change conflicts with current upstream Python Apprise conversion behavior. The remaining top-level review-body entries are duplicates or aggregates mapped to queue items above.
+- [ ] Re-pulled CodeRabbit threads and reviews
+- [ ] No unhandled top-level review-body comment remains

--- a/internal/notify/format_convert_test.go
+++ b/internal/notify/format_convert_test.go
@@ -1,6 +1,7 @@
 package notify_test
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
 
@@ -26,6 +27,143 @@ func TestConvertMessageFormatRejectsInvalidFormats(t *testing.T) {
 	}
 	if _, err := notify.ConvertMessageFormat("body", "text", "bad"); err == nil {
 		t.Fatalf("expected invalid output format error")
+	}
+}
+
+func TestTargetFormatConversionCorpusAcrossWorkflowTargets(t *testing.T) {
+	body := strings.Join([]string{
+		"# Deploy Summary",
+		"",
+		"**Bold** _Italics_ ~~Strike~~ [Docs](https://example.com/docs)",
+		"",
+		"`inline code`",
+		"",
+		"```go",
+		"if x > 0 { return `tick` }\\path",
+		"```",
+		"",
+		"- first",
+		"- second",
+		"",
+		"<em>inline html</em>",
+	}, "\n")
+
+	cases := []struct {
+		name       string
+		rawURL     string
+		assertBody func(t *testing.T, body string)
+		assertSpec func(t *testing.T, spec notify.RequestSpec)
+	}{
+		{
+			name:   "json html",
+			rawURL: "json://example.com/notify?format=html",
+			assertBody: func(t *testing.T, converted string) {
+				t.Helper()
+				assertContainsAll(t, converted, "<h1>Deploy Summary</h1>", "<strong>Bold</strong>", "<em>Italics</em>", "<pre><code class=\"language-go\">")
+			},
+		},
+		{
+			name:   "workflow markdown",
+			rawURL: "workflow://example.com/WORKFLOWID/SIGNATURE?format=markdown&image=no",
+			assertBody: func(t *testing.T, converted string) {
+				t.Helper()
+				assertContainsAll(t, converted, "**Bold**", "```go", "<em>inline html</em>")
+			},
+			assertSpec: func(t *testing.T, spec notify.RequestSpec) {
+				t.Helper()
+				assertContainsAll(t, workflowTextBlock(t, spec, "body"), "**Bold**", "```go", "<em>inline html</em>")
+			},
+		},
+		{
+			name:   "workflow html",
+			rawURL: "workflow://example.com/WORKFLOWID/SIGNATURE?format=html&image=no",
+			assertBody: func(t *testing.T, converted string) {
+				t.Helper()
+				assertContainsAll(t, converted, "<h1>Deploy Summary</h1>", "<strong>Bold</strong>", "<pre><code class=\"language-go\">")
+			},
+			assertSpec: func(t *testing.T, spec notify.RequestSpec) {
+				t.Helper()
+				assertContainsAll(t, workflowTextBlock(t, spec, "body"), "<h1>Deploy Summary</h1>", "<strong>Bold</strong>", "<pre><code class=\"language-go\">")
+			},
+		},
+		{
+			name:   "ntfy markdown",
+			rawURL: "ntfy://example.com/topic?format=markdown&image=no",
+			assertBody: func(t *testing.T, converted string) {
+				t.Helper()
+				assertContainsAll(t, converted, "**Bold**", "```go")
+			},
+			assertSpec: func(t *testing.T, spec notify.RequestSpec) {
+				t.Helper()
+				if spec.Headers["X-Markdown"] != "yes" {
+					t.Fatalf("expected ntfy markdown header, got %#v", spec.Headers["X-Markdown"])
+				}
+				assertContainsAll(t, jsonStringField(t, spec.Body, "message"), "**Bold**", "```go")
+			},
+		},
+		{
+			name:   "discord markdown",
+			rawURL: "discord://123456/token?format=markdown",
+			assertBody: func(t *testing.T, converted string) {
+				t.Helper()
+				assertContainsAll(t, converted, "**Bold**", "```go")
+			},
+			assertSpec: func(t *testing.T, spec notify.RequestSpec) {
+				t.Helper()
+				assertContainsAll(t, discordEmbedDescription(t, spec), "**Bold**", "```go")
+			},
+		},
+		{
+			name:   "telegram markdown v1",
+			rawURL: "tgram://123456:abcdef/7890/?format=markdown&mdv=v1",
+			assertBody: func(t *testing.T, converted string) {
+				t.Helper()
+				assertContainsAll(t, converted, "*Deploy Summary*", "*Bold*", "_Italics_", "Strike", "[Docs](https://example.com/docs)", "```\nif x > 0 { return `tick` }\\path\n```", "- first", "- second")
+				assertNotContains(t, converted, "~Strike~")
+				assertNotContains(t, converted, "````")
+			},
+		},
+		{
+			name:   "telegram markdown v2",
+			rawURL: "tgram://123456:abcdef/7890/?format=markdown&mdv=v2",
+			assertBody: func(t *testing.T, converted string) {
+				t.Helper()
+				assertContainsAll(t, converted, "*Deploy Summary*", "*Bold*", "_Italics_", "[Docs](https://example.com/docs)", "```\nif x > 0 { return \\`tick\\` }\\\\path\n```", "\\- first", "\\- second")
+				assertNotContains(t, converted, "````")
+			},
+		},
+		{
+			name:   "telegram html",
+			rawURL: "tgram://123456:abcdef/7890/?format=html",
+			assertBody: func(t *testing.T, converted string) {
+				t.Helper()
+				assertContainsAll(t, converted, "<b>Deploy Summary</b>", "<b>Bold</b>", "<i>Italics</i>", `<a href="https://example.com/docs">Docs</a>`, "<pre><code>if x &gt; 0 { return `tick` }\\path\n</code></pre>", "- first", "- second")
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			parsed, err := notify.ParseURL(tc.rawURL)
+			if err != nil {
+				t.Fatalf("parse url: %v", err)
+			}
+			converted, err := notify.ConvertMessageFormatForTarget(parsed, body, "markdown")
+			if err != nil {
+				t.Fatalf("convert target body: %v", err)
+			}
+			tc.assertBody(t, converted)
+
+			specs := testutil.CaptureGoRequests(t, func() error {
+				return notify.SendTargetURL(tc.rawURL, body, "generalized parser", "markdown", notify.NotifyInfo)
+			})
+			if len(specs) != 1 {
+				t.Fatalf("expected one request, got %d", len(specs))
+			}
+			if tc.assertSpec != nil {
+				tc.assertSpec(t, specs[0])
+			}
+		})
 	}
 }
 
@@ -57,4 +195,76 @@ func assertConvertMessageFormatRequestParity(t *testing.T, body, inputFormat, ou
 	})
 
 	testutil.AssertRequestSpecSequenceMatches(t, pythonSpecs, goSpecs)
+}
+
+func assertContainsAll(t *testing.T, value string, fragments ...string) {
+	t.Helper()
+	for _, fragment := range fragments {
+		if !strings.Contains(value, fragment) {
+			t.Fatalf("expected %q to contain %q", value, fragment)
+		}
+	}
+}
+
+func assertNotContains(t *testing.T, value, fragment string) {
+	t.Helper()
+	if strings.Contains(value, fragment) {
+		t.Fatalf("expected %q not to contain %q", value, fragment)
+	}
+}
+
+func jsonStringField(t *testing.T, body, field string) string {
+	t.Helper()
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		t.Fatalf("decode json body: %v", err)
+	}
+	value, ok := payload[field].(string)
+	if !ok {
+		t.Fatalf("expected string field %q in %#v", field, payload[field])
+	}
+	return value
+}
+
+func workflowTextBlock(t *testing.T, spec notify.RequestSpec, id string) string {
+	t.Helper()
+	var payload struct {
+		Attachments []struct {
+			Content struct {
+				Body []map[string]any `json:"body"`
+			} `json:"content"`
+		} `json:"attachments"`
+	}
+	if err := json.Unmarshal([]byte(spec.Body), &payload); err != nil {
+		t.Fatalf("decode workflow body: %v", err)
+	}
+	for _, attachment := range payload.Attachments {
+		for _, block := range attachment.Content.Body {
+			if block["id"] == id {
+				text, ok := block["text"].(string)
+				if !ok {
+					t.Fatalf("expected workflow block %q text to be a string: %#v", id, block["text"])
+				}
+				return text
+			}
+		}
+	}
+	t.Fatalf("workflow text block %q not found in %s", id, spec.Body)
+	return ""
+}
+
+func discordEmbedDescription(t *testing.T, spec notify.RequestSpec) string {
+	t.Helper()
+	var payload struct {
+		Embeds []struct {
+			Description string `json:"description"`
+		} `json:"embeds"`
+	}
+	if err := json.Unmarshal([]byte(spec.Body), &payload); err != nil {
+		t.Fatalf("decode discord body: %v", err)
+	}
+	if len(payload.Embeds) != 1 {
+		t.Fatalf("expected one discord embed, got %d", len(payload.Embeds))
+	}
+	return payload.Embeds[0].Description
 }

--- a/internal/notify/live/telegram_live_test.go
+++ b/internal/notify/live/telegram_live_test.go
@@ -1,4 +1,4 @@
-package notify_test
+package live_test
 
 import (
 	"bytes"
@@ -8,6 +8,9 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/unraid/apprise-go/internal/notify"
+	"github.com/unraid/apprise-go/internal/testutil"
 )
 
 func TestTelegramLiveFormattingAgainstBotAPI(t *testing.T) {
@@ -107,6 +110,23 @@ func telegramLiveDestination(t *testing.T) any {
 
 	t.Skip("set APPRISE_GO_TELEGRAM_CHAT_ID to run Telegram live validation against an explicit destination")
 	return nil
+}
+
+func captureTelegramPayload(t *testing.T, rawURL, body, title, bodyFormat string) map[string]any {
+	t.Helper()
+
+	specs := testutil.CaptureGoRequests(t, func() error {
+		return notify.SendTargetURL(rawURL, body, title, bodyFormat, notify.NotifyInfo)
+	})
+	if len(specs) != 1 {
+		t.Fatalf("expected one request, got %d", len(specs))
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(specs[0].Body), &payload); err != nil {
+		t.Fatalf("decode payload: %v", err)
+	}
+	return payload
 }
 
 func telegramLiveAssertParseable(t *testing.T, token string, payload map[string]any) {

--- a/internal/notify/live/telegram_live_test.go
+++ b/internal/notify/live/telegram_live_test.go
@@ -139,13 +139,13 @@ func telegramLiveAssertParseable(t *testing.T, token string, payload map[string]
 
 	req, err := http.NewRequest(http.MethodPost, "https://api.telegram.org/bot"+token+"/sendMessage", bytes.NewReader(data))
 	if err != nil {
-		t.Fatalf("new telegram request: %v", err)
+		t.Fatalf("new telegram request: %s", telegramLiveRedactToken(err, token))
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := telegramLiveClient().Do(req)
 	if err != nil {
-		t.Fatalf("telegram sendMessage: %v", err)
+		t.Fatalf("telegram sendMessage: %s", telegramLiveRedactToken(err, token))
 	}
 	defer resp.Body.Close()
 
@@ -170,4 +170,32 @@ func telegramLiveAssertParseable(t *testing.T, token string, payload map[string]
 
 func telegramLiveClient() *http.Client {
 	return &http.Client{Timeout: 20 * time.Second}
+}
+
+func TestTelegramLiveRedactToken(t *testing.T) {
+	token := "123456:secret"
+	err := &urlErrorString{message: "Post \"https://api.telegram.org/bot123456:secret/sendMessage\": timeout"}
+
+	got := telegramLiveRedactToken(err, token)
+	if strings.Contains(got, token) {
+		t.Fatalf("redacted error still contains token: %q", got)
+	}
+	if !strings.Contains(got, "<redacted>") {
+		t.Fatalf("redacted error missing placeholder: %q", got)
+	}
+}
+
+func telegramLiveRedactToken(err error, token string) string {
+	if err == nil {
+		return ""
+	}
+	return strings.ReplaceAll(err.Error(), token, "<redacted>")
+}
+
+type urlErrorString struct {
+	message string
+}
+
+func (e *urlErrorString) Error() string {
+	return e.message
 }

--- a/internal/notify/telegram_format_convert.go
+++ b/internal/notify/telegram_format_convert.go
@@ -75,17 +75,20 @@ func telegramHTMLFromHTML(content string) string {
 	}
 
 	var out strings.Builder
-	renderTelegramHTMLNode(&out, root)
+	renderTelegramHTMLNode(&out, root, false)
 	return strings.Trim(out.String(), "\n")
 }
 
-func renderTelegramHTMLNode(out *strings.Builder, node *nethtml.Node) {
+func renderTelegramHTMLNode(out *strings.Builder, node *nethtml.Node, inCode bool) {
 	if node.Type == nethtml.TextNode {
+		if !inCode && strings.TrimSpace(node.Data) == "" && strings.ContainsAny(node.Data, "\r\n") {
+			return
+		}
 		out.WriteString(html.EscapeString(node.Data))
 		return
 	}
 	if node.Type != nethtml.ElementNode {
-		renderTelegramHTMLChildren(out, node)
+		renderTelegramHTMLChildren(out, node, inCode)
 		return
 	}
 
@@ -98,46 +101,53 @@ func renderTelegramHTMLNode(out *strings.Builder, node *nethtml.Node) {
 	case "a":
 		href := htmlAttr(node, "href")
 		if href == "" {
-			renderTelegramHTMLChildren(out, node)
+			renderTelegramHTMLChildren(out, node, inCode)
 			break
 		}
 		out.WriteString(`<a href="`)
 		out.WriteString(html.EscapeString(href))
 		out.WriteString(`">`)
-		renderTelegramHTMLChildren(out, node)
+		renderTelegramHTMLChildren(out, node, inCode)
 		out.WriteString("</a>")
 	case "b", "strong":
 		out.WriteString("<b>")
-		renderTelegramHTMLChildren(out, node)
+		renderTelegramHTMLChildren(out, node, inCode)
 		out.WriteString("</b>")
 	case "blockquote":
 		out.WriteString("<blockquote>")
-		renderTelegramHTMLChildren(out, node)
+		renderTelegramHTMLChildren(out, node, inCode)
 		out.WriteString("</blockquote>")
 	case "br":
 		ensureLineBreak(out)
 	case "code":
 		out.WriteString("<code>")
-		renderTelegramHTMLChildren(out, node)
+		renderTelegramHTMLChildren(out, node, true)
 		out.WriteString("</code>")
 	case "del", "s", "strike":
 		out.WriteString("<s>")
-		renderTelegramHTMLChildren(out, node)
+		renderTelegramHTMLChildren(out, node, inCode)
 		out.WriteString("</s>")
 	case "em", "i":
 		out.WriteString("<i>")
-		renderTelegramHTMLChildren(out, node)
+		renderTelegramHTMLChildren(out, node, inCode)
 		out.WriteString("</i>")
+	case "h1", "h2", "h3", "h4", "h5", "h6":
+		out.WriteString("<b>")
+		renderTelegramHTMLChildren(out, node, inCode)
+		out.WriteString("</b>")
+	case "li":
+		out.WriteString("- ")
+		renderTelegramHTMLChildren(out, node, inCode)
 	case "pre":
 		out.WriteString("<pre>")
-		renderTelegramHTMLChildren(out, node)
+		renderTelegramHTMLChildren(out, node, true)
 		out.WriteString("</pre>")
 	case "u", "ins":
 		out.WriteString("<u>")
-		renderTelegramHTMLChildren(out, node)
+		renderTelegramHTMLChildren(out, node, inCode)
 		out.WriteString("</u>")
 	default:
-		renderTelegramHTMLChildren(out, node)
+		renderTelegramHTMLChildren(out, node, inCode)
 	}
 
 	if _, ok := telegramHTMLBlockTags[tag]; ok {
@@ -145,9 +155,9 @@ func renderTelegramHTMLNode(out *strings.Builder, node *nethtml.Node) {
 	}
 }
 
-func renderTelegramHTMLChildren(out *strings.Builder, node *nethtml.Node) {
+func renderTelegramHTMLChildren(out *strings.Builder, node *nethtml.Node, inCode bool) {
 	for child := node.FirstChild; child != nil; child = child.NextSibling {
-		renderTelegramHTMLNode(out, child)
+		renderTelegramHTMLNode(out, child, inCode)
 	}
 }
 
@@ -168,7 +178,10 @@ func telegramMarkdownFromHTML(content, markdownMode string) string {
 func renderTelegramMarkdownNode(out *strings.Builder, node *nethtml.Node, markdownMode string, inCode bool) {
 	if node.Type == nethtml.TextNode {
 		if inCode {
-			out.WriteString(escapeTelegramMarkdownCodeText(node.Data))
+			out.WriteString(escapeTelegramMarkdownCodeText(node.Data, markdownMode))
+			return
+		}
+		if strings.TrimSpace(node.Data) == "" && strings.ContainsAny(node.Data, "\r\n") {
 			return
 		}
 		out.WriteString(escapeTelegramMarkdownText(node.Data, markdownMode))
@@ -203,19 +216,38 @@ func renderTelegramMarkdownNode(out *strings.Builder, node *nethtml.Node, markdo
 	case "br":
 		ensureLineBreak(out)
 	case "code":
+		if inCode {
+			renderTelegramMarkdownChildren(out, node, markdownMode, true)
+			break
+		}
 		out.WriteString("`")
 		renderTelegramMarkdownChildren(out, node, markdownMode, true)
 		out.WriteString("`")
 	case "del", "s", "strike":
-		out.WriteString("~")
+		if markdownMode == "MarkdownV2" {
+			out.WriteString("~")
+		}
 		renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
-		out.WriteString("~")
+		if markdownMode == "MarkdownV2" {
+			out.WriteString("~")
+		}
 	case "em", "i":
 		out.WriteString("_")
 		renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
 		out.WriteString("_")
+	case "h1", "h2", "h3", "h4", "h5", "h6":
+		out.WriteString("*")
+		renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
+		out.WriteString("*")
+	case "li":
+		if markdownMode == "MarkdownV2" {
+			out.WriteString("\\- ")
+		} else {
+			out.WriteString("- ")
+		}
+		renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
 	case "pre":
-		out.WriteString("```")
+		out.WriteString("```\n")
 		renderTelegramMarkdownChildren(out, node, markdownMode, true)
 		out.WriteString("```")
 	default:
@@ -233,7 +265,10 @@ func renderTelegramMarkdownChildren(out *strings.Builder, node *nethtml.Node, ma
 	}
 }
 
-func escapeTelegramMarkdownCodeText(value string) string {
+func escapeTelegramMarkdownCodeText(value, markdownMode string) string {
+	if markdownMode != "MarkdownV2" {
+		return value
+	}
 	replacer := strings.NewReplacer(
 		"\\", "\\\\",
 		"`", "\\`",

--- a/internal/notify/telegram_format_test.go
+++ b/internal/notify/telegram_format_test.go
@@ -23,7 +23,7 @@ func TestTelegramConvertsStandardMarkdownToMarkdownV1(t *testing.T) {
 	if payload["parse_mode"] != "MARKDOWN" {
 		t.Fatalf("expected MARKDOWN parse mode, got %#v", payload["parse_mode"])
 	}
-	if payload["text"] != "~Strike~ *Bold* _Italics_ Text" {
+	if payload["text"] != "Strike *Bold* _Italics_ Text" {
 		t.Fatalf("expected Telegram markdown body, got %#v", payload["text"])
 	}
 }
@@ -47,6 +47,95 @@ func TestTelegramConvertsStandardMarkdownToTelegramHTML(t *testing.T) {
 	}
 	if payload["text"] != "<s>Strike</s> <b>Bold</b> <i>Italics</i> Text" {
 		t.Fatalf("expected Telegram HTML body, got %#v", payload["text"])
+	}
+}
+
+func TestTelegramConvertsInlineHTMLInMarkdownInputToTelegramHTML(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=html", "<b>Bold</b> <i>Italics</i> Text", "", "markdown")
+
+	if payload["parse_mode"] != "HTML" {
+		t.Fatalf("expected HTML parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "<b>Bold</b> <i>Italics</i> Text" {
+		t.Fatalf("expected Telegram HTML body, got %#v", payload["text"])
+	}
+}
+
+func TestTelegramConvertsHTMLInputToMarkdownV1(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v1", "<b>Bold</b> <i>Italics</i> Text", "", "html")
+
+	if payload["parse_mode"] != "MARKDOWN" {
+		t.Fatalf("expected MARKDOWN parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "*Bold* _Italics_ Text" {
+		t.Fatalf("expected Telegram markdown body, got %#v", payload["text"])
+	}
+}
+
+func TestTelegramConvertsHTMLInputToMarkdownV2(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v2", "<b>Bold</b> <i>Italics</i> Text", "", "html")
+
+	if payload["parse_mode"] != "MarkdownV2" {
+		t.Fatalf("expected MarkdownV2 parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "*Bold* _Italics_ Text" {
+		t.Fatalf("expected Telegram markdown body, got %#v", payload["text"])
+	}
+}
+
+func TestTelegramConvertsMarkdownFencedCodeToMarkdownV1Pre(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v1", "**Bold**\n_Italics_\n```go\nif x > 0 { return `tick` }\\path\n```", "", "markdown")
+
+	if payload["parse_mode"] != "MARKDOWN" {
+		t.Fatalf("expected MARKDOWN parse mode, got %#v", payload["parse_mode"])
+	}
+	text, ok := payload["text"].(string)
+	if !ok {
+		t.Fatalf("expected text payload, got %#v", payload["text"])
+	}
+	if strings.Contains(text, "````") {
+		t.Fatalf("expected fenced code not to be double wrapped, got %q", text)
+	}
+	if !strings.Contains(text, "```\nif x > 0 { return `tick` }\\path\n```") {
+		t.Fatalf("expected Telegram markdown pre block, got %q", text)
+	}
+	if strings.Contains(text, "\\`") || strings.Contains(text, "\\\\path") {
+		t.Fatalf("expected Markdown v1 pre text not to show escape backslashes, got %q", text)
+	}
+}
+
+func TestTelegramConvertsMarkdownFencedCodeToMarkdownV2Pre(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v2", "```go\nif x > 0 { return `tick` }\\path\n```", "", "markdown")
+
+	if payload["parse_mode"] != "MarkdownV2" {
+		t.Fatalf("expected MarkdownV2 parse mode, got %#v", payload["parse_mode"])
+	}
+	text, ok := payload["text"].(string)
+	if !ok {
+		t.Fatalf("expected text payload, got %#v", payload["text"])
+	}
+	if strings.Contains(text, "````") {
+		t.Fatalf("expected fenced code not to be double wrapped, got %q", text)
+	}
+	if !strings.Contains(text, "if x > 0 { return \\`tick\\` }\\\\path") {
+		t.Fatalf("expected Telegram markdown pre body with code-only escaping, got %q", text)
+	}
+}
+
+func TestTelegramConvertsMarkdownFencedCodeToTelegramHTML(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=html", "**Bold**\n_Italics_\n```\ncode\n```", "", "markdown")
+
+	if payload["parse_mode"] != "HTML" {
+		t.Fatalf("expected HTML parse mode, got %#v", payload["parse_mode"])
+	}
+	text, ok := payload["text"].(string)
+	if !ok {
+		t.Fatalf("expected text payload, got %#v", payload["text"])
+	}
+	for _, expected := range []string{"<b>Bold</b>", "<i>Italics</i>", "<pre><code>code\n</code></pre>"} {
+		if !strings.Contains(text, expected) {
+			t.Fatalf("expected %q in Telegram HTML body, got %q", expected, text)
+		}
 	}
 }
 
@@ -74,7 +163,7 @@ func TestTelegramMarkdownV2PreEscapesOnlyBackticksAndBackslashes(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected text payload, got %#v", payload["text"])
 	}
-	if text != "```if x > 0 { return path\\\\name }```" {
+	if text != "```\nif x > 0 { return path\\\\name }```" {
 		t.Fatalf("expected minimally escaped pre text, got %q", text)
 	}
 	for _, overescaped := range []string{`\>`, `\{`, `\}`} {

--- a/internal/notify/telegram_live_test.go
+++ b/internal/notify/telegram_live_test.go
@@ -16,7 +16,7 @@ func TestTelegramLiveFormattingAgainstBotAPI(t *testing.T) {
 		t.Skip("set APPRISE_GO_TELEGRAM_BOT_TOKEN to validate Telegram formatting against the live Bot API")
 	}
 
-	chatID, realDestination := telegramLiveDestination(t, token)
+	chatID := telegramLiveDestination(t)
 	generalizedMarkdown := strings.Join([]string{
 		"# Deploy Summary",
 		"",
@@ -93,109 +93,23 @@ func TestTelegramLiveFormattingAgainstBotAPI(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			payload := captureTelegramPayload(t, tc.rawURL, tc.body, "", tc.bodyFormat)
 			payload["chat_id"] = chatID
-			telegramLiveAssertParseable(t, token, payload, realDestination)
+			telegramLiveAssertParseable(t, token, payload)
 		})
 	}
 }
 
-func telegramLiveDestination(t *testing.T, token string) (any, bool) {
+func telegramLiveDestination(t *testing.T) any {
 	t.Helper()
 
 	if chatID := strings.TrimSpace(os.Getenv("APPRISE_GO_TELEGRAM_CHAT_ID")); chatID != "" {
-		return chatID, true
+		return chatID
 	}
 
-	if chatID := telegramLiveLatestChatID(t, token); chatID != nil {
-		return chatID, true
-	}
-
-	return telegramLiveBotID(t, token), false
-}
-
-func telegramLiveLatestChatID(t *testing.T, token string) any {
-	t.Helper()
-
-	client := telegramLiveClient()
-	resp, err := client.Get("https://api.telegram.org/bot" + token + "/getUpdates")
-	if err != nil {
-		t.Fatalf("telegram getUpdates: %v", err)
-	}
-	defer resp.Body.Close()
-
-	var payload struct {
-		OK     bool `json:"ok"`
-		Result []struct {
-			Message *struct {
-				Chat struct {
-					ID       int64  `json:"id"`
-					Username string `json:"username"`
-				} `json:"chat"`
-			} `json:"message"`
-			ChannelPost *struct {
-				Chat struct {
-					ID       int64  `json:"id"`
-					Username string `json:"username"`
-				} `json:"chat"`
-			} `json:"channel_post"`
-		} `json:"result"`
-		Description string `json:"description"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		t.Fatalf("decode telegram getUpdates: %v", err)
-	}
-	if !payload.OK {
-		t.Fatalf("telegram getUpdates failed: status=%d description=%q", resp.StatusCode, payload.Description)
-	}
-
-	for i := len(payload.Result) - 1; i >= 0; i-- {
-		if payload.Result[i].Message != nil {
-			if payload.Result[i].Message.Chat.ID != 0 {
-				return payload.Result[i].Message.Chat.ID
-			}
-			if payload.Result[i].Message.Chat.Username != "" {
-				return "@" + payload.Result[i].Message.Chat.Username
-			}
-		}
-		if payload.Result[i].ChannelPost != nil {
-			if payload.Result[i].ChannelPost.Chat.ID != 0 {
-				return payload.Result[i].ChannelPost.Chat.ID
-			}
-			if payload.Result[i].ChannelPost.Chat.Username != "" {
-				return "@" + payload.Result[i].ChannelPost.Chat.Username
-			}
-		}
-	}
-
+	t.Skip("set APPRISE_GO_TELEGRAM_CHAT_ID to run Telegram live validation against an explicit destination")
 	return nil
 }
 
-func telegramLiveBotID(t *testing.T, token string) int64 {
-	t.Helper()
-
-	client := telegramLiveClient()
-	resp, err := client.Get("https://api.telegram.org/bot" + token + "/getMe")
-	if err != nil {
-		t.Fatalf("telegram getMe: %v", err)
-	}
-	defer resp.Body.Close()
-
-	var payload struct {
-		OK     bool `json:"ok"`
-		Result struct {
-			ID int64 `json:"id"`
-		} `json:"result"`
-		Description string `json:"description"`
-	}
-	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
-		t.Fatalf("decode telegram getMe: %v", err)
-	}
-	if !payload.OK || payload.Result.ID == 0 {
-		t.Fatalf("telegram getMe failed: status=%d description=%q", resp.StatusCode, payload.Description)
-	}
-	return payload.Result.ID
-}
-
-func telegramLiveAssertParseable(t *testing.T, token string, payload map[string]any, realDestination bool) {
+func telegramLiveAssertParseable(t *testing.T, token string, payload map[string]any) {
 	t.Helper()
 
 	data, err := json.Marshal(payload)
@@ -226,10 +140,10 @@ func telegramLiveAssertParseable(t *testing.T, token string, payload map[string]
 	if strings.Contains(result.Description, "can't parse entities") {
 		t.Fatalf("telegram rejected formatting: status=%d description=%q payload=%q", resp.StatusCode, result.Description, payload["text"])
 	}
-	if realDestination && !result.OK {
+	if !result.OK {
 		t.Fatalf("telegram rejected delivered message: status=%d code=%d description=%q", resp.StatusCode, result.ErrorCode, result.Description)
 	}
-	if resp.StatusCode != http.StatusForbidden && resp.StatusCode >= http.StatusBadRequest {
+	if resp.StatusCode >= http.StatusBadRequest {
 		t.Fatalf("telegram rejected request before parse validation completed: status=%d code=%d description=%q", resp.StatusCode, result.ErrorCode, result.Description)
 	}
 }

--- a/internal/notify/telegram_live_test.go
+++ b/internal/notify/telegram_live_test.go
@@ -1,0 +1,239 @@
+package notify_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTelegramLiveFormattingAgainstBotAPI(t *testing.T) {
+	token := strings.TrimSpace(os.Getenv("APPRISE_GO_TELEGRAM_BOT_TOKEN"))
+	if token == "" {
+		t.Skip("set APPRISE_GO_TELEGRAM_BOT_TOKEN to validate Telegram formatting against the live Bot API")
+	}
+
+	chatID, realDestination := telegramLiveDestination(t, token)
+	generalizedMarkdown := strings.Join([]string{
+		"# Deploy Summary",
+		"",
+		"**Bold** _Italics_ ~~Strike~~ [Docs](https://example.com/docs)",
+		"",
+		"`inline code`",
+		"",
+		"```go",
+		"if x > 0 { return `tick` }\\path",
+		"```",
+		"",
+		"- first",
+		"- second",
+		"",
+		"<em>inline html</em>",
+	}, "\n")
+	cases := []struct {
+		name       string
+		rawURL     string
+		body       string
+		bodyFormat string
+	}{
+		{
+			name:       "markdown v1 fenced code",
+			rawURL:     "tgram://123456:abcdef/7890/?format=markdown&mdv=v1",
+			body:       "**Bold**\n_Italics_\n```\ncode\n```",
+			bodyFormat: "markdown",
+		},
+		{
+			name:       "markdown v2 fenced code",
+			rawURL:     "tgram://123456:abcdef/7890/?format=markdown&mdv=v2",
+			body:       "```go\nif x > 0 { return `tick` }\\path\n```",
+			bodyFormat: "markdown",
+		},
+		{
+			name:       "telegram html fenced code",
+			rawURL:     "tgram://123456:abcdef/7890/?format=html",
+			body:       "**Bold**\n_Italics_\n```\ncode\n```",
+			bodyFormat: "markdown",
+		},
+		{
+			name:       "html input to markdown v1",
+			rawURL:     "tgram://123456:abcdef/7890/?format=markdown&mdv=v1",
+			body:       "<b>Bold</b> <i>Italics</i> Text",
+			bodyFormat: "html",
+		},
+		{
+			name:       "html input to markdown v2",
+			rawURL:     "tgram://123456:abcdef/7890/?format=markdown&mdv=v2",
+			body:       "<b>Bold</b> <i>Italics</i> Text",
+			bodyFormat: "html",
+		},
+		{
+			name:       "generalized markdown corpus to markdown v1",
+			rawURL:     "tgram://123456:abcdef/7890/?format=markdown&mdv=v1",
+			body:       generalizedMarkdown,
+			bodyFormat: "markdown",
+		},
+		{
+			name:       "generalized markdown corpus to markdown v2",
+			rawURL:     "tgram://123456:abcdef/7890/?format=markdown&mdv=v2",
+			body:       generalizedMarkdown,
+			bodyFormat: "markdown",
+		},
+		{
+			name:       "generalized markdown corpus to html",
+			rawURL:     "tgram://123456:abcdef/7890/?format=html",
+			body:       generalizedMarkdown,
+			bodyFormat: "markdown",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := captureTelegramPayload(t, tc.rawURL, tc.body, "", tc.bodyFormat)
+			payload["chat_id"] = chatID
+			telegramLiveAssertParseable(t, token, payload, realDestination)
+		})
+	}
+}
+
+func telegramLiveDestination(t *testing.T, token string) (any, bool) {
+	t.Helper()
+
+	if chatID := strings.TrimSpace(os.Getenv("APPRISE_GO_TELEGRAM_CHAT_ID")); chatID != "" {
+		return chatID, true
+	}
+
+	if chatID := telegramLiveLatestChatID(t, token); chatID != nil {
+		return chatID, true
+	}
+
+	return telegramLiveBotID(t, token), false
+}
+
+func telegramLiveLatestChatID(t *testing.T, token string) any {
+	t.Helper()
+
+	client := telegramLiveClient()
+	resp, err := client.Get("https://api.telegram.org/bot" + token + "/getUpdates")
+	if err != nil {
+		t.Fatalf("telegram getUpdates: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		OK     bool `json:"ok"`
+		Result []struct {
+			Message *struct {
+				Chat struct {
+					ID       int64  `json:"id"`
+					Username string `json:"username"`
+				} `json:"chat"`
+			} `json:"message"`
+			ChannelPost *struct {
+				Chat struct {
+					ID       int64  `json:"id"`
+					Username string `json:"username"`
+				} `json:"chat"`
+			} `json:"channel_post"`
+		} `json:"result"`
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode telegram getUpdates: %v", err)
+	}
+	if !payload.OK {
+		t.Fatalf("telegram getUpdates failed: status=%d description=%q", resp.StatusCode, payload.Description)
+	}
+
+	for i := len(payload.Result) - 1; i >= 0; i-- {
+		if payload.Result[i].Message != nil {
+			if payload.Result[i].Message.Chat.ID != 0 {
+				return payload.Result[i].Message.Chat.ID
+			}
+			if payload.Result[i].Message.Chat.Username != "" {
+				return "@" + payload.Result[i].Message.Chat.Username
+			}
+		}
+		if payload.Result[i].ChannelPost != nil {
+			if payload.Result[i].ChannelPost.Chat.ID != 0 {
+				return payload.Result[i].ChannelPost.Chat.ID
+			}
+			if payload.Result[i].ChannelPost.Chat.Username != "" {
+				return "@" + payload.Result[i].ChannelPost.Chat.Username
+			}
+		}
+	}
+
+	return nil
+}
+
+func telegramLiveBotID(t *testing.T, token string) int64 {
+	t.Helper()
+
+	client := telegramLiveClient()
+	resp, err := client.Get("https://api.telegram.org/bot" + token + "/getMe")
+	if err != nil {
+		t.Fatalf("telegram getMe: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var payload struct {
+		OK     bool `json:"ok"`
+		Result struct {
+			ID int64 `json:"id"`
+		} `json:"result"`
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		t.Fatalf("decode telegram getMe: %v", err)
+	}
+	if !payload.OK || payload.Result.ID == 0 {
+		t.Fatalf("telegram getMe failed: status=%d description=%q", resp.StatusCode, payload.Description)
+	}
+	return payload.Result.ID
+}
+
+func telegramLiveAssertParseable(t *testing.T, token string, payload map[string]any, realDestination bool) {
+	t.Helper()
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal telegram payload: %v", err)
+	}
+
+	req, err := http.NewRequest(http.MethodPost, "https://api.telegram.org/bot"+token+"/sendMessage", bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("new telegram request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := telegramLiveClient().Do(req)
+	if err != nil {
+		t.Fatalf("telegram sendMessage: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var result struct {
+		OK          bool   `json:"ok"`
+		ErrorCode   int    `json:"error_code"`
+		Description string `json:"description"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		t.Fatalf("decode telegram sendMessage: %v", err)
+	}
+	if strings.Contains(result.Description, "can't parse entities") {
+		t.Fatalf("telegram rejected formatting: status=%d description=%q payload=%q", resp.StatusCode, result.Description, payload["text"])
+	}
+	if realDestination && !result.OK {
+		t.Fatalf("telegram rejected delivered message: status=%d code=%d description=%q", resp.StatusCode, result.ErrorCode, result.Description)
+	}
+	if resp.StatusCode != http.StatusForbidden && resp.StatusCode >= http.StatusBadRequest {
+		t.Fatalf("telegram rejected request before parse validation completed: status=%d code=%d description=%q", resp.StatusCode, result.ErrorCode, result.Description)
+	}
+}
+
+func telegramLiveClient() *http.Client {
+	return &http.Client{Timeout: 20 * time.Second}
+}


### PR DESCRIPTION
## Summary

- Convert standard Markdown/HTML into Telegram-safe HTML, Markdown v1, and MarkdownV2 instead of passing incompatible formatting through raw.
- Fix fenced code/pre handling so nested `<pre><code>` does not produce invalid Telegram Markdown and code escaping is applied only where Telegram requires it.
- Add a generalized format-conversion corpus across JSON, Workflows, ntfy, Discord, and Telegram paths, plus an opt-in live Telegram Bot API suite gated by environment variables.

## Root Cause

Telegram uses non-standard Markdown modes. The previous conversion path reused generic Markdown/HTML output without fully adapting nested code blocks, unsupported v1 strikethrough, MarkdownV2 reserved characters, list markers, headings, and whitespace-only HTML parser nodes. That produced bad requests for some pre/code payloads and visible escape/formatting artifacts in delivered messages.

## Validation

- `go test ./...`
- Live Telegram Bot API validation was run locally with `APPRISE_GO_TELEGRAM_BOT_TOKEN` and `APPRISE_GO_TELEGRAM_CHAT_ID`; the secret values are not stored in the repo.

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Telegram message formatting with enhanced code-block handling and more robust escaping across Markdown/HTML conversions.

* **Tests**
  * Added broad unit tests validating message format conversion across notification targets.
  * Added live Telegram integration tests, including token-redaction checks and validation against the Bot API.

* **Documentation**
  * Updated WIP snapshot and execution log to reflect current fixes and review status.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/apprise-go/pull/60?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->