### PR TITLE
fix(telegram): preserve markdown paragraph spacing

### DIFF
--- a/internal/notify/format_convert_test.go
+++ b/internal/notify/format_convert_test.go
@@ -137,7 +137,7 @@ func TestTargetFormatConversionCorpusAcrossWorkflowTargets(t *testing.T) {
 			rawURL: "tgram://123456:abcdef/7890/?format=html",
 			assertBody: func(t *testing.T, converted string) {
 				t.Helper()
-				assertContainsAll(t, converted, "<b>Deploy Summary</b>", "<b>Bold</b>", "<i>Italics</i>", `<a href="https://example.com/docs">Docs</a>`, "<pre><code>if x &gt; 0 { return `tick` }\\path\n</code></pre>", "- first", "- second")
+				assertContainsAll(t, converted, "<b>Deploy Summary</b>", "<b>Bold</b>", "<i>Italics</i>", `<a href="https://example.com/docs">Docs</a>`, "<pre><code>if x &gt; 0 { return `tick` }\\path\r\n</code></pre>", "- first", "- second")
 			},
 		},
 	}

--- a/internal/notify/telegram_format_convert.go
+++ b/internal/notify/telegram_format_convert.go
@@ -344,7 +344,6 @@ func escapeTelegramMarkdownText(value, markdownMode string) string {
 		"*", "\\*",
 		"_", "\\_",
 		"`", "\\`",
-		"[", "\\[",
 	)
 	return replacer.Replace(value)
 }

--- a/internal/notify/telegram_format_convert.go
+++ b/internal/notify/telegram_format_convert.go
@@ -22,6 +22,18 @@ var telegramHTMLBlockTags = map[string]struct{}{
 	"pre":        {},
 }
 
+var telegramHTMLParagraphTags = map[string]struct{}{
+	"blockquote": {},
+	"div":        {},
+	"h1":         {},
+	"h2":         {},
+	"h3":         {},
+	"h4":         {},
+	"h5":         {},
+	"h6":         {},
+	"p":          {},
+}
+
 func convertTelegramMessageFormat(content, inputFormat, outputFormat, markdownVersion string) (string, error) {
 	input := normalizeNotifyFormat(inputFormat)
 	output := normalizeNotifyFormat(outputFormat)
@@ -81,10 +93,11 @@ func telegramHTMLFromHTML(content string) string {
 
 func renderTelegramHTMLNode(out *strings.Builder, node *nethtml.Node, inCode bool) {
 	if node.Type == nethtml.TextNode {
-		if !inCode && strings.TrimSpace(node.Data) == "" && strings.ContainsAny(node.Data, "\r\n") {
+		data := telegramTextNodeData(node)
+		if !inCode && strings.TrimSpace(data) == "" && strings.ContainsAny(data, "\r\n") {
 			return
 		}
-		out.WriteString(html.EscapeString(node.Data))
+		out.WriteString(html.EscapeString(data))
 		return
 	}
 	if node.Type != nethtml.ElementNode {
@@ -93,8 +106,12 @@ func renderTelegramHTMLNode(out *strings.Builder, node *nethtml.Node, inCode boo
 	}
 
 	tag := strings.ToLower(node.Data)
-	if _, ok := telegramHTMLBlockTags[tag]; ok && out.Len() > 0 {
-		ensureLineBreak(out)
+	if out.Len() > 0 {
+		if _, ok := telegramHTMLParagraphTags[tag]; ok {
+			ensureParagraphBreak(out)
+		} else if _, ok := telegramHTMLBlockTags[tag]; ok {
+			ensureLineBreak(out)
+		}
 	}
 
 	switch tag {
@@ -150,7 +167,9 @@ func renderTelegramHTMLNode(out *strings.Builder, node *nethtml.Node, inCode boo
 		renderTelegramHTMLChildren(out, node, inCode)
 	}
 
-	if _, ok := telegramHTMLBlockTags[tag]; ok {
+	if _, ok := telegramHTMLParagraphTags[tag]; ok {
+		ensureParagraphBreak(out)
+	} else if _, ok := telegramHTMLBlockTags[tag]; ok {
 		ensureLineBreak(out)
 	}
 }
@@ -177,14 +196,15 @@ func telegramMarkdownFromHTML(content, markdownMode string) string {
 
 func renderTelegramMarkdownNode(out *strings.Builder, node *nethtml.Node, markdownMode string, inCode bool) {
 	if node.Type == nethtml.TextNode {
+		data := telegramTextNodeData(node)
 		if inCode {
-			out.WriteString(escapeTelegramMarkdownCodeText(node.Data, markdownMode))
+			out.WriteString(escapeTelegramMarkdownCodeText(data, markdownMode))
 			return
 		}
-		if strings.TrimSpace(node.Data) == "" && strings.ContainsAny(node.Data, "\r\n") {
+		if strings.TrimSpace(data) == "" && strings.ContainsAny(data, "\r\n") {
 			return
 		}
-		out.WriteString(escapeTelegramMarkdownText(node.Data, markdownMode))
+		out.WriteString(escapeTelegramMarkdownText(data, markdownMode))
 		return
 	}
 	if node.Type != nethtml.ElementNode {
@@ -193,8 +213,12 @@ func renderTelegramMarkdownNode(out *strings.Builder, node *nethtml.Node, markdo
 	}
 
 	tag := strings.ToLower(node.Data)
-	if _, ok := telegramHTMLBlockTags[tag]; ok && out.Len() > 0 {
-		ensureLineBreak(out)
+	if out.Len() > 0 {
+		if _, ok := telegramHTMLParagraphTags[tag]; ok {
+			ensureParagraphBreak(out)
+		} else if _, ok := telegramHTMLBlockTags[tag]; ok {
+			ensureLineBreak(out)
+		}
 	}
 
 	switch tag {
@@ -254,7 +278,9 @@ func renderTelegramMarkdownNode(out *strings.Builder, node *nethtml.Node, markdo
 		renderTelegramMarkdownChildren(out, node, markdownMode, inCode)
 	}
 
-	if _, ok := telegramHTMLBlockTags[tag]; ok {
+	if _, ok := telegramHTMLParagraphTags[tag]; ok {
+		ensureParagraphBreak(out)
+	} else if _, ok := telegramHTMLBlockTags[tag]; ok {
 		ensureLineBreak(out)
 	}
 }
@@ -330,6 +356,61 @@ func htmlAttr(node *nethtml.Node, key string) string {
 		}
 	}
 	return ""
+}
+
+// telegramTextNodeData returns node text while trimming leading CR/LF only after
+// a preceding br element, as reported by previousElementTag, to compensate for
+// markdown parsers that emit a formatting newline after <br>. Other whitespace
+// is preserved in non-br contexts.
+func telegramTextNodeData(node *nethtml.Node) string {
+	if node == nil {
+		return ""
+	}
+	data := node.Data
+	if previousElementTag(node) == "br" {
+		data = strings.TrimLeft(data, "\r\n")
+	}
+	return data
+}
+
+// previousElementTag walks previous siblings to find the nearest non-empty
+// element node. It skips whitespace-only text nodes because HTML parsers often
+// expose formatting whitespace as siblings, returns the lowercase tag name of
+// the first previous element node found, and returns an empty string for nil
+// input or when only non-whitespace text/other nodes are found.
+func previousElementTag(node *nethtml.Node) string {
+	if node == nil {
+		return ""
+	}
+	for sibling := node.PrevSibling; sibling != nil; sibling = sibling.PrevSibling {
+		if sibling.Type == nethtml.TextNode && strings.TrimSpace(sibling.Data) == "" {
+			continue
+		}
+		if sibling.Type == nethtml.ElementNode {
+			return strings.ToLower(sibling.Data)
+		}
+		return ""
+	}
+	return ""
+}
+
+// ensureParagraphBreak mutates the provided *strings.Builder in-place so it
+// ends with one paragraph break. It no-ops for empty builders or existing
+// double-newline endings, appends one newline after a single trailing newline,
+// and appends two newlines otherwise, making it safe to call multiple times.
+func ensureParagraphBreak(out *strings.Builder) {
+	if out.Len() == 0 {
+		return
+	}
+	value := out.String()
+	switch {
+	case strings.HasSuffix(value, "\n\n"):
+		return
+	case strings.HasSuffix(value, "\n"):
+		out.WriteByte('\n')
+	default:
+		out.WriteString("\n\n")
+	}
 }
 
 func ensureLineBreak(out *strings.Builder) {

--- a/internal/notify/telegram_format_convert.go
+++ b/internal/notify/telegram_format_convert.go
@@ -88,7 +88,7 @@ func telegramHTMLFromHTML(content string) string {
 
 	var out strings.Builder
 	renderTelegramHTMLNode(&out, root, false)
-	return strings.Trim(out.String(), "\n")
+	return normalizeTelegramHTMLLineBreaks(out.String())
 }
 
 func renderTelegramHTMLNode(out *strings.Builder, node *nethtml.Node, inCode bool) {
@@ -355,6 +355,14 @@ func htmlAttr(node *nethtml.Node, key string) string {
 		}
 	}
 	return ""
+}
+
+func normalizeTelegramHTMLLineBreaks(value string) string {
+	if strings.HasSuffix(value, "\n\n") {
+		value = value[:len(value)-1]
+	}
+	value = strings.ReplaceAll(value, "\r\n", "\n")
+	return strings.ReplaceAll(value, "\n", "\r\n")
 }
 
 // telegramTextNodeData returns node text while trimming leading CR/LF only after

--- a/internal/notify/telegram_format_test.go
+++ b/internal/notify/telegram_format_test.go
@@ -56,7 +56,7 @@ func TestTelegramConvertsStandardMarkdownToTelegramHTML(t *testing.T) {
 	if payload["parse_mode"] != "HTML" {
 		t.Fatalf("expected HTML parse mode, got %#v", payload["parse_mode"])
 	}
-	if payload["text"] != "<s>Strike</s> <b>Bold</b> <i>Italics</i> Text" {
+	if payload["text"] != "<s>Strike</s> <b>Bold</b> <i>Italics</i> Text\r\n" {
 		t.Fatalf("expected Telegram HTML body, got %#v", payload["text"])
 	}
 }
@@ -67,7 +67,7 @@ func TestTelegramConvertsInlineHTMLInMarkdownInputToTelegramHTML(t *testing.T) {
 	if payload["parse_mode"] != "HTML" {
 		t.Fatalf("expected HTML parse mode, got %#v", payload["parse_mode"])
 	}
-	if payload["text"] != "<b>Bold</b> <i>Italics</i> Text" {
+	if payload["text"] != "<b>Bold</b> <i>Italics</i> Text\r\n" {
 		t.Fatalf("expected Telegram HTML body, got %#v", payload["text"])
 	}
 }
@@ -143,7 +143,7 @@ func TestTelegramConvertsMarkdownFencedCodeToTelegramHTML(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected text payload, got %#v", payload["text"])
 	}
-	for _, expected := range []string{"<b>Bold</b>", "<i>Italics</i>", "<pre><code>code\n</code></pre>"} {
+	for _, expected := range []string{"<b>Bold</b>", "<i>Italics</i>", "<pre><code>code\r\n</code></pre>"} {
 		if !strings.Contains(text, expected) {
 			t.Fatalf("expected %q in Telegram HTML body, got %q", expected, text)
 		}
@@ -249,7 +249,7 @@ func TestTelegramPreservesMarkdownParagraphSpacing(t *testing.T) {
 				"Uptime: <b>TESTER</b>",
 				"",
 				"<i>Beware of a tall blond man with one black shoe.</i>",
-			}, "\n"),
+			}, "\r\n") + "\r\n",
 		},
 	}
 

--- a/internal/notify/telegram_format_test.go
+++ b/internal/notify/telegram_format_test.go
@@ -28,6 +28,17 @@ func TestTelegramConvertsStandardMarkdownToMarkdownV1(t *testing.T) {
 	}
 }
 
+func TestTelegramMarkdownV1DoesNotEscapeLiteralBrackets(t *testing.T) {
+	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v1", "**[status]**", "", "markdown")
+
+	if payload["parse_mode"] != "MARKDOWN" {
+		t.Fatalf("expected MARKDOWN parse mode, got %#v", payload["parse_mode"])
+	}
+	if payload["text"] != "*[status]*" {
+		t.Fatalf("expected Telegram markdown body without visible bracket escapes, got %#v", payload["text"])
+	}
+}
+
 func TestTelegramConvertsStandardMarkdownToMarkdownV2(t *testing.T) {
 	payload := captureTelegramPayload(t, "tgram://123456:abcdef/7890/?format=markdown&mdv=v2", "~~Strike~~ **Bold** _Italics_ Text", "", "markdown")
 

--- a/internal/notify/telegram_format_test.go
+++ b/internal/notify/telegram_format_test.go
@@ -185,6 +185,78 @@ func TestTelegramMarkdownV2PreservesLinks(t *testing.T) {
 	}
 }
 
+func TestTelegramPreservesMarkdownParagraphSpacing(t *testing.T) {
+	body := strings.Join([]string{
+		"**--- Header ---**",
+		"",
+		"Hostname: **server**",
+		"Date/Time: **Today**",
+		"Uptime: **TESTER**",
+		"",
+		"_Beware of a tall blond man with one black shoe._",
+	}, "\n")
+
+	cases := []struct {
+		name     string
+		rawURL   string
+		expected string
+	}{
+		{
+			name:   "markdown v1",
+			rawURL: "tgram://123456:abcdef/7890/?format=markdown&mdv=v1",
+			expected: strings.Join([]string{
+				"*— Header —*",
+				"",
+				"Hostname: *server*",
+				"Date/Time: *Today*",
+				"Uptime: *TESTER*",
+				"",
+				"_Beware of a tall blond man with one black shoe._",
+			}, "\n"),
+		},
+		{
+			name:   "markdown v2",
+			rawURL: "tgram://123456:abcdef/7890/?format=markdown&mdv=v2",
+			expected: strings.Join([]string{
+				"*— Header —*",
+				"",
+				"Hostname: *server*",
+				"Date/Time: *Today*",
+				"Uptime: *TESTER*",
+				"",
+				"_Beware of a tall blond man with one black shoe\\._",
+			}, "\n"),
+		},
+		{
+			name:   "html",
+			rawURL: "tgram://123456:abcdef/7890/?format=html",
+			expected: strings.Join([]string{
+				"<b>— Header —</b>",
+				"",
+				"Hostname: <b>server</b>",
+				"Date/Time: <b>Today</b>",
+				"Uptime: <b>TESTER</b>",
+				"",
+				"<i>Beware of a tall blond man with one black shoe.</i>",
+			}, "\n"),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			payload := captureTelegramPayload(t, tc.rawURL, body, "", "markdown")
+
+			text, ok := payload["text"].(string)
+			if !ok {
+				t.Fatalf("expected text payload, got %#v", payload["text"])
+			}
+			if text != tc.expected {
+				t.Fatalf("expected Telegram body\n%q\ngot\n%q", tc.expected, text)
+			}
+		})
+	}
+}
+
 func TestTelegramTextFormatUsesHTMLParseMode(t *testing.T) {
 	assertTelegramFormatParity(t, "tgram://123456:abcdef/7890/?format=text", "<b>plain</b>", "Title", "text")
 }


### PR DESCRIPTION
## Summary
- Preserves Telegram paragraph spacing when converting markdown to Telegram Markdown v1, MarkdownV2, and HTML payloads.
- Separates paragraph block breaks from single hard line breaks in the Telegram renderer.
- Aligns Markdown v1 literal bracket handling with the upstream Python backport and live Telegram client behavior so `[` does not render with a visible backslash.
- Normalizes Telegram HTML output to Python-compatible CRLF/trailing-CRLF bytes for the shared cross-test matrix.
- Adds regression coverage for the line-spacing sample reported in #48 and Markdown v1 bracket rendering.

## Root Cause
The Telegram renderers treated paragraph-like blocks and `<br>` hard line breaks through the same single-newline path. The markdown parser also emits text-node newlines after `<br>` elements, which caused blank lines to appear in the wrong places before the payload reached Telegram. Follow-up cross-testing against the Python upstream backport and live Telegram showed Markdown v1 should not escape literal `[` because Telegram displays that backslash in the client.

## Cross-Test Notes
The apprise-go branch was cross-tested against the Python upstream draft PR for shared Telegram cases: HTML paragraph spacing, Markdown v1, MarkdownV2, HTML-to-MarkdownV2 docs links, text-to-MarkdownV2 escaping, and Markdown v1 literal brackets. The shared payload text now matches exactly, including CRLF/trailing-CRLF normalization for Telegram HTML output.

## Validation
- `go test ./internal/notify`

Fixes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preservation of paragraph and blank-line spacing across Telegram HTML and Markdown outputs; normalized line-ending behavior and more consistent paragraph breaks.
  * Literal square brackets are no longer escaped in legacy Markdown mode, so bracketed text appears as authored.

* **Tests**
  * Added regression tests verifying paragraph/blank-line spacing and literal-bracket behavior across HTML, Markdown V1, and Markdown V2, including line-ending expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unraid/apprise-go/pull/64?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
