### PR TITLE
feat(pushover): support html and markdown message formats

### DIFF
--- a/internal/notify/pushover.go
+++ b/internal/notify/pushover.go
@@ -38,6 +38,7 @@ type PushoverTarget struct {
 	supplementalURLTitle string
 	retry                int
 	expire               int
+	format               string
 }
 
 func NewPushoverTarget(target *ParsedURL) (*PushoverTarget, error) {
@@ -100,6 +101,7 @@ func NewPushoverTarget(target *ParsedURL) (*PushoverTarget, error) {
 		supplementalURLTitle: strings.TrimSpace(target.Query["url_title"]),
 		retry:                retry,
 		expire:               expire,
+		format:               normalizeNotifyFormat(target.Query["format"]),
 	}, nil
 }
 
@@ -122,6 +124,13 @@ func (p *PushoverTarget) BuildRequest(body, title string, notifyType NotifyType)
 	}
 	if p.supplementalURLTitle != "" {
 		values.Set("url_title", p.supplementalURLTitle)
+	}
+	switch p.format {
+	case "html":
+		values.Set("html", "1")
+	case "markdown":
+		values.Set("message", markdownToHTML(body))
+		values.Set("html", "1")
 	}
 	if p.priority == 2 {
 		values.Set("retry", fmt.Sprintf("%d", p.retry))

--- a/internal/notify/pushover_format_test.go
+++ b/internal/notify/pushover_format_test.go
@@ -1,0 +1,54 @@
+package notify
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestPushoverFormat(t *testing.T) {
+	build := func(raw, body string) url.Values {
+		t.Helper()
+		parsed, err := ParseURL(raw)
+		if err != nil {
+			t.Fatalf("ParseURL(%q): %v", raw, err)
+		}
+		tgt, err := NewPushoverTarget(parsed)
+		if err != nil {
+			t.Fatalf("NewPushoverTarget(%q): %v", raw, err)
+		}
+		spec, err := tgt.BuildRequest(body, "Title", NotifyInfo)
+		if err != nil {
+			t.Fatalf("BuildRequest(%q): %v", raw, err)
+		}
+		vals, err := url.ParseQuery(spec.Body)
+		if err != nil {
+			t.Fatalf("parse body: %v", err)
+		}
+		return vals
+	}
+
+	htmlVals := build("pover://user@token?format=html", "<b>hi</b>")
+	if got := htmlVals.Get("html"); got != "1" {
+		t.Errorf("format=html: html=%q, want 1", got)
+	}
+	if got := htmlVals.Get("message"); got != "<b>hi</b>" {
+		t.Errorf("format=html: message=%q, want unchanged", got)
+	}
+
+	mdVals := build("pover://user@token?format=markdown", "**hi**")
+	if got := mdVals.Get("html"); got != "1" {
+		t.Errorf("format=markdown: html=%q, want 1", got)
+	}
+	if got, want := mdVals.Get("message"), markdownToHTML("**hi**"); got != want {
+		t.Errorf("format=markdown: message=%q, want %q", got, want)
+	}
+
+	for _, raw := range []string{
+		"pover://user@token",
+		"pover://user@token?format=text",
+	} {
+		if v := build(raw, "<b>hi</b>"); v.Has("html") {
+			t.Errorf("%s: html should be absent, got %q", raw, v.Get("html"))
+		}
+	}
+}


### PR DESCRIPTION
Pushover advertises a `format` arg (html/markdown/text) in its schema, but the send path ignored it, so `?format=html` did nothing.

This reads `format` from the target URL like the ntfy provider does. `html` sets Pushover's `html=1`; `markdown` converts the body to HTML and sets `html=1`; text and the default stay as plain text. This matches how the Python Apprise Pushover plugin handles `format`. Adds a test.