### PR TITLE
feat: support notification attachments

### DIFF
--- a/apprise.go
+++ b/apprise.go
@@ -30,11 +30,12 @@ var ErrNoTargets = errors.New("apprise: no notification URLs configured")
 type Option func(*notifyOptions)
 
 type notifyOptions struct {
-	title         string
-	notifyType    NotifyType
-	inputFormat   string
-	attachments   []notify.Attachment
-	attachmentErr error
+	title              string
+	notifyType         NotifyType
+	inputFormat        string
+	rawAttachments     []string
+	attachmentMaxBytes int64
+	attachmentErr      error
 }
 
 // Apprise stores notification target URLs and sends messages to them.
@@ -98,15 +99,22 @@ func WithInputFormat(inputFormat string) Option {
 	}
 }
 
-// WithAttachments attaches one or more local file paths or attachment URLs to the notification.
-func WithAttachments(rawAttachments ...string) Option {
+// WithAttachmentMaxBytes sets the maximum size for each remote attachment.
+func WithAttachmentMaxBytes(maxBytes int64) Option {
 	return func(opts *notifyOptions) {
-		attachments, err := notify.ParseAttachments(rawAttachments)
-		if err != nil {
-			opts.attachmentErr = err
+		if maxBytes <= 0 {
+			opts.attachmentErr = fmt.Errorf("maximum attachment size must be positive")
 			return
 		}
-		opts.attachments = append(opts.attachments, attachments...)
+		opts.attachmentMaxBytes = maxBytes
+	}
+}
+
+// WithAttachments attaches one or more local file paths or trusted attachment URLs to the notification.
+// Attachment URLs are fetched as provided; do not pass untrusted end-user URLs.
+func WithAttachments(rawAttachments ...string) Option {
+	return func(opts *notifyOptions) {
+		opts.rawAttachments = append(opts.rawAttachments, rawAttachments...)
 	}
 }
 
@@ -182,10 +190,14 @@ func (a *Apprise) Send(body string, options ...Option) error {
 	if opts.attachmentErr != nil {
 		return opts.attachmentErr
 	}
+	attachments, err := notify.ParseAttachmentsWithMaxBytes(opts.rawAttachments, opts.attachmentMaxBytes)
+	if err != nil {
+		return err
+	}
 
 	var errs []error
 	for _, rawURL := range urls {
-		if err := notify.SendTargetURLWithAttachments(rawURL, body, opts.title, opts.inputFormat, opts.notifyType, opts.attachments); err != nil {
+		if err := notify.SendTargetURLWithAttachments(rawURL, body, opts.title, opts.inputFormat, opts.notifyType, attachments); err != nil {
 			errs = append(errs, &TargetError{
 				URL: rawURL,
 				Err: err,
@@ -206,7 +218,8 @@ func Send(rawURLs []string, body string, options ...Option) error {
 
 func defaultNotifyOptions() notifyOptions {
 	return notifyOptions{
-		notifyType:  NotifyInfo,
-		inputFormat: "text",
+		notifyType:         NotifyInfo,
+		inputFormat:        "text",
+		attachmentMaxBytes: notify.DefaultMaxAttachmentBytes,
 	}
 }

--- a/apprise.go
+++ b/apprise.go
@@ -30,9 +30,11 @@ var ErrNoTargets = errors.New("apprise: no notification URLs configured")
 type Option func(*notifyOptions)
 
 type notifyOptions struct {
-	title       string
-	notifyType  NotifyType
-	inputFormat string
+	title         string
+	notifyType    NotifyType
+	inputFormat   string
+	attachments   []notify.Attachment
+	attachmentErr error
 }
 
 // Apprise stores notification target URLs and sends messages to them.
@@ -93,6 +95,18 @@ func WithNotifyType(notifyType NotifyType) Option {
 func WithInputFormat(inputFormat string) Option {
 	return func(opts *notifyOptions) {
 		opts.inputFormat = inputFormat
+	}
+}
+
+// WithAttachments attaches one or more local file paths or attachment URLs to the notification.
+func WithAttachments(rawAttachments ...string) Option {
+	return func(opts *notifyOptions) {
+		attachments, err := notify.ParseAttachments(rawAttachments)
+		if err != nil {
+			opts.attachmentErr = err
+			return
+		}
+		opts.attachments = append(opts.attachments, attachments...)
 	}
 }
 
@@ -165,9 +179,13 @@ func (a *Apprise) Send(body string, options ...Option) error {
 		}
 	}
 
+	if opts.attachmentErr != nil {
+		return opts.attachmentErr
+	}
+
 	var errs []error
 	for _, rawURL := range urls {
-		if err := notify.SendTargetURL(rawURL, body, opts.title, opts.inputFormat, opts.notifyType); err != nil {
+		if err := notify.SendTargetURLWithAttachments(rawURL, body, opts.title, opts.inputFormat, opts.notifyType, opts.attachments); err != nil {
 			errs = append(errs, &TargetError{
 				URL: rawURL,
 				Err: err,

--- a/apprise_test.go
+++ b/apprise_test.go
@@ -5,8 +5,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -101,12 +99,7 @@ func TestAppriseAddRejectsUnsupportedSchema(t *testing.T) {
 
 func writeAttachmentFixture(t *testing.T, name, body string) string {
 	t.Helper()
-
-	path := filepath.Join(t.TempDir(), name)
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-		t.Fatalf("write attachment fixture: %v", err)
-	}
-	return path
+	return testutil.WriteAttachmentFixture(t, name, body)
 }
 
 func captureRequestSpec(t *testing.T, r *http.Request) notify.RequestSpec {

--- a/apprise_test.go
+++ b/apprise_test.go
@@ -52,6 +52,22 @@ func TestAppriseSendJSONTargetWithAttachmentMatchesPython(t *testing.T) {
 	testutil.AssertRequestSpecSequenceMatches(t, pythonRequests, goRequests)
 }
 
+func TestAppriseSendAttachmentMaxBytes(t *testing.T) {
+	attachmentServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("12345"))
+	}))
+	defer attachmentServer.Close()
+
+	client := New()
+	if err := client.Add("json://example.com/notify"); err != nil {
+		t.Fatalf("add target: %v", err)
+	}
+	err := client.Send("hello", WithAttachments(attachmentServer.URL), WithAttachmentMaxBytes(4))
+	if err == nil || !strings.Contains(err.Error(), "attachment exceeds maximum size") {
+		t.Fatalf("error = %v, want maximum size error", err)
+	}
+}
+
 func TestAppriseSendConvertsInputFormat(t *testing.T) {
 	testutil.RequirePythonApprise(t)
 

--- a/apprise_test.go
+++ b/apprise_test.go
@@ -5,6 +5,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -27,6 +29,26 @@ func TestAppriseSendJSONTarget(t *testing.T) {
 			return err
 		}
 		return client.Send(body, WithTitle(title))
+	})
+
+	testutil.AssertRequestSpecSequenceMatches(t, pythonRequests, goRequests)
+}
+
+func TestAppriseSendJSONTargetWithAttachmentMatchesPython(t *testing.T) {
+	testutil.RequirePythonApprise(t)
+
+	attachment := writeAttachmentFixture(t, "report.txt", "attachment body\n")
+	targetURL := "json://example.com/notify"
+	body := "hello"
+	title := "Greeting"
+
+	pythonRequests := testutil.CapturePythonRequestsWithAttachments(t, targetURL, body, title, []string{attachment})
+	goRequests := testutil.CaptureGoRequests(t, func() error {
+		client := New()
+		if err := client.Add(targetURL); err != nil {
+			return err
+		}
+		return client.Send(body, WithTitle(title), WithAttachments(attachment))
 	})
 
 	testutil.AssertRequestSpecSequenceMatches(t, pythonRequests, goRequests)
@@ -75,6 +97,16 @@ func TestAppriseAddRejectsUnsupportedSchema(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "unsupported URL scheme: unknown") {
 		t.Fatalf("error = %v, want unsupported schema", err)
 	}
+}
+
+func writeAttachmentFixture(t *testing.T, name, body string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write attachment fixture: %v", err)
+	}
+	return path
 }
 
 func captureRequestSpec(t *testing.T, r *http.Request) notify.RequestSpec {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -320,11 +320,7 @@ func Run(args []string, stdout, stderr io.Writer) int {
 			continue
 		}
 
-		if sender, ok := target.(notify.AttachmentSender); ok {
-			err = sender.SendWithAttachments(sendBody, title, nt, attachments)
-		} else {
-			err = target.Send(sendBody, title, nt)
-		}
+		err = notify.DispatchSend(target, sendBody, title, nt, attachments)
 		if err != nil {
 			fmt.Fprintf(stderr, "%s notify error: %s\n", notify.TargetSchemaName(parsed.Scheme), err)
 			failed = true

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -272,9 +272,14 @@ func Run(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
+	attachments, err := notify.ParseAttachments(opts.attachments)
+	if err != nil {
+		fmt.Fprintf(stderr, "attachment error: %s\n", err)
+		return 2
+	}
+
 	// TODO: Wire these options into CLI behavior once the runtime supports them.
 	_ = opts.disableAsync
-	_ = opts.attachments
 	_ = opts.pluginPaths
 	_ = opts.theme
 	_ = opts.recursionDepth
@@ -315,7 +320,12 @@ func Run(args []string, stdout, stderr io.Writer) int {
 			continue
 		}
 
-		if err := target.Send(sendBody, title, nt); err != nil {
+		if sender, ok := target.(notify.AttachmentSender); ok {
+			err = sender.SendWithAttachments(sendBody, title, nt, attachments)
+		} else {
+			err = target.Send(sendBody, title, nt)
+		}
+		if err != nil {
 			fmt.Fprintf(stderr, "%s notify error: %s\n", notify.TargetSchemaName(parsed.Scheme), err)
 			failed = true
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -216,6 +216,74 @@ func TestRunConvertsMarkdownInputForHTMLTargetFormat(t *testing.T) {
 	testutil.AssertRequestSpecSequenceMatches(t, pythonRequests, goRequests)
 }
 
+func TestRunAttachJSONMatchesPythonApprise(t *testing.T) {
+	testutil.RequirePythonApprise(t)
+
+	attachment := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(attachment, []byte("attachment body\n"), 0o600); err != nil {
+		t.Fatalf("write attachment fixture: %v", err)
+	}
+
+	targetURL := "json://example.com/notify"
+	body := "hello"
+	title := "Greeting"
+	pythonSpecs := testutil.CapturePythonRequestsWithAttachments(t, targetURL, body, title, []string{attachment})
+
+	goSpecs := testutil.CaptureGoRequests(t, func() error {
+		stdout := &bytes.Buffer{}
+		stderr := &bytes.Buffer{}
+		code := Run([]string{"-b", body, "-t", title, "--attach", attachment, targetURL}, stdout, stderr)
+		if code != 0 {
+			return fmt.Errorf("Run failed with code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+		}
+		return nil
+	})
+
+	testutil.AssertRequestSpecSequenceMatches(t, pythonSpecs, goSpecs)
+}
+
+func TestRunAttachMailtoMatchesPythonApprise(t *testing.T) {
+	testutil.RequirePythonApprise(t)
+
+	attachment := filepath.Join(t.TempDir(), "report.txt")
+	if err := os.WriteFile(attachment, []byte("attachment body\n"), 0o600); err != nil {
+		t.Fatalf("write attachment fixture: %v", err)
+	}
+
+	capture := testutil.StartSMTPCapture(t)
+	defer func() {
+		_ = capture.Close()
+	}()
+
+	rawURL := "mailto://" + capture.Addr() + "/recipient@example.com?from=sender@example.com&format=text&mode=insecure"
+	body := "hello"
+	title := "Greeting"
+
+	pyStdout, pyStderr, err := testutil.RunApprise(t, "-b", body, "-t", title, "--attach", attachment, rawURL)
+	if err != nil {
+		t.Fatalf("python apprise failed: %v stdout=%s stderr=%s", err, pyStdout, pyStderr)
+	}
+	pythonMessages := capture.Messages()
+	if len(pythonMessages) == 0 {
+		t.Fatalf("no smtp message captured from python")
+	}
+
+	capture.Reset()
+
+	stdout := &bytes.Buffer{}
+	stderr := &bytes.Buffer{}
+	code := Run([]string{"-b", body, "-t", title, "--attach", attachment, rawURL}, stdout, stderr)
+	if code != 0 {
+		t.Fatalf("expected success, got code=%d stdout=%s stderr=%s", code, stdout.String(), stderr.String())
+	}
+	goMessages := capture.Messages()
+	if len(goMessages) == 0 {
+		t.Fatalf("no smtp message captured from go")
+	}
+
+	testutil.AssertSMTPMessageSequencesMatch(t, pythonMessages, goMessages)
+}
+
 func helpWorkflowCases() []struct {
 	name string
 	args []string

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -219,10 +219,7 @@ func TestRunConvertsMarkdownInputForHTMLTargetFormat(t *testing.T) {
 func TestRunAttachJSONMatchesPythonApprise(t *testing.T) {
 	testutil.RequirePythonApprise(t)
 
-	attachment := filepath.Join(t.TempDir(), "report.txt")
-	if err := os.WriteFile(attachment, []byte("attachment body\n"), 0o600); err != nil {
-		t.Fatalf("write attachment fixture: %v", err)
-	}
+	attachment := testutil.WriteAttachmentFixture(t, "report.txt", "attachment body\n")
 
 	targetURL := "json://example.com/notify"
 	body := "hello"
@@ -245,10 +242,7 @@ func TestRunAttachJSONMatchesPythonApprise(t *testing.T) {
 func TestRunAttachMailtoMatchesPythonApprise(t *testing.T) {
 	testutil.RequirePythonApprise(t)
 
-	attachment := filepath.Join(t.TempDir(), "report.txt")
-	if err := os.WriteFile(attachment, []byte("attachment body\n"), 0o600); err != nil {
-		t.Fatalf("write attachment fixture: %v", err)
-	}
+	attachment := testutil.WriteAttachmentFixture(t, "report.txt", "attachment body\n")
 
 	capture := testutil.StartSMTPCapture(t)
 	defer func() {

--- a/internal/notify/apprise_api.go
+++ b/internal/notify/apprise_api.go
@@ -1,9 +1,12 @@
 package notify
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"mime/multipart"
+	"net/textproto"
 	"net/url"
 	"regexp"
 	"sort"
@@ -68,6 +71,10 @@ func NewAppriseTarget(target *ParsedURL) (*AppriseTarget, error) {
 }
 
 func (a *AppriseTarget) BuildRequest(body, title string, notifyType NotifyType) (RequestSpec, error) {
+	return a.BuildRequestWithAttachments(body, title, notifyType, nil)
+}
+
+func (a *AppriseTarget) BuildRequestWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) (RequestSpec, error) {
 	scheme := "http"
 	if strings.ToLower(a.target.Scheme) == "apprises" {
 		scheme = "https"
@@ -107,6 +114,20 @@ func (a *AppriseTarget) BuildRequest(body, title string, notifyType NotifyType) 
 			values.Add("tag", tag)
 		}
 
+		if len(attachments) > 0 {
+			payload, contentType, err := buildAppriseMultipart(values, attachments)
+			if err != nil {
+				return RequestSpec{}, err
+			}
+			headers["Content-Type"] = contentType
+			return RequestSpec{
+				Method:  "POST",
+				URL:     u.String(),
+				Headers: headers,
+				Body:    payload,
+			}, nil
+		}
+
 		headers["Content-Type"] = "application/x-www-form-urlencoded"
 		return RequestSpec{
 			Method:  "POST",
@@ -125,6 +146,9 @@ func (a *AppriseTarget) BuildRequest(body, title string, notifyType NotifyType) 
 	if len(a.tags) > 0 {
 		payload["tag"] = a.tags
 	}
+	if len(attachments) > 0 {
+		payload["attachments"] = attachmentPayloads(attachments)
+	}
 
 	data, err := json.Marshal(payload)
 	if err != nil {
@@ -141,12 +165,44 @@ func (a *AppriseTarget) BuildRequest(body, title string, notifyType NotifyType) 
 }
 
 func (a *AppriseTarget) Send(body, title string, notifyType NotifyType) error {
-	spec, err := a.BuildRequest(body, title, notifyType)
+	return a.SendWithAttachments(body, title, notifyType, nil)
+}
+
+func (a *AppriseTarget) SendWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) error {
+	spec, err := a.BuildRequestWithAttachments(body, title, notifyType, attachments)
 	if err != nil {
 		return err
 	}
 
 	return SendRequest(spec)
+}
+
+func buildAppriseMultipart(values url.Values, attachments []Attachment) (string, string, error) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for key, entries := range values {
+		for _, value := range entries {
+			if err := writer.WriteField(key, value); err != nil {
+				return "", "", err
+			}
+		}
+	}
+	for i, attachment := range attachments {
+		header := textproto.MIMEHeader{}
+		header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="file%02d"; filename="%s"`, i+1, escapeMultipartParam(attachment.Name)))
+		header.Set("Content-Type", attachment.MIMEType)
+		part, err := writer.CreatePart(header)
+		if err != nil {
+			return "", "", err
+		}
+		if _, err := part.Write(attachment.Data); err != nil {
+			return "", "", err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return "", "", err
+	}
+	return body.String(), writer.FormDataContentType(), nil
 }
 
 func splitPath(pathValue string) []string {

--- a/internal/notify/attachment.go
+++ b/internal/notify/attachment.go
@@ -13,7 +13,8 @@ import (
 	"time"
 )
 
-const maxAttachmentBytes int64 = 25 * 1024 * 1024
+// DefaultMaxAttachmentBytes is the default cap used when fetching remote attachments.
+const DefaultMaxAttachmentBytes int64 = 25 * 1024 * 1024
 
 var attachmentHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
@@ -25,9 +26,17 @@ type Attachment struct {
 }
 
 func ParseAttachments(rawValues []string) ([]Attachment, error) {
+	return ParseAttachmentsWithMaxBytes(rawValues, DefaultMaxAttachmentBytes)
+}
+
+// ParseAttachmentsWithMaxBytes parses attachments using maxBytes for each remote attachment fetch.
+func ParseAttachmentsWithMaxBytes(rawValues []string, maxBytes int64) ([]Attachment, error) {
+	if maxBytes <= 0 {
+		return nil, fmt.Errorf("maximum attachment size must be positive")
+	}
 	attachments := make([]Attachment, 0, len(rawValues))
 	for _, raw := range rawValues {
-		attachment, err := ParseAttachment(raw)
+		attachment, err := ParseAttachmentWithMaxBytes(raw, maxBytes)
 		if err != nil {
 			return nil, err
 		}
@@ -37,9 +46,17 @@ func ParseAttachments(rawValues []string) ([]Attachment, error) {
 }
 
 func ParseAttachment(raw string) (Attachment, error) {
+	return ParseAttachmentWithMaxBytes(raw, DefaultMaxAttachmentBytes)
+}
+
+// ParseAttachmentWithMaxBytes parses an attachment using maxBytes for a remote attachment fetch.
+func ParseAttachmentWithMaxBytes(raw string, maxBytes int64) (Attachment, error) {
 	source := strings.TrimSpace(raw)
 	if source == "" {
 		return Attachment{}, fmt.Errorf("empty attachment")
+	}
+	if maxBytes <= 0 {
+		return Attachment{}, fmt.Errorf("maximum attachment size must be positive")
 	}
 
 	location, params := splitAttachmentParams(source)
@@ -53,7 +70,7 @@ func ParseAttachment(raw string) (Attachment, error) {
 	var err error
 	switch strings.ToLower(attachmentScheme(location)) {
 	case "http", "https":
-		data, err = readHTTPAttachment(location)
+		data, err = readHTTPAttachment(location, maxBytes)
 	case "file":
 		data, location, err = readFileURLAttachment(location)
 	default:
@@ -133,11 +150,14 @@ func attachmentScheme(raw string) string {
 	return parsed.Scheme
 }
 
-func readHTTPAttachment(raw string) ([]byte, error) {
-	return readHTTPAttachmentWithClient(raw, attachmentHTTPClient, maxAttachmentBytes)
+func readHTTPAttachment(raw string, maxBytes int64) ([]byte, error) {
+	return readHTTPAttachmentWithClient(raw, attachmentHTTPClient, maxBytes)
 }
 
 func readHTTPAttachmentWithClient(raw string, client *http.Client, maxBytes int64) ([]byte, error) {
+	// Attachment URLs are explicit caller input, matching Python Apprise's
+	// trusted-URL behavior. Do not pass untrusted end-user URLs here without
+	// applying application-level SSRF policy before calling WithAttachments.
 	req, err := http.NewRequest(http.MethodGet, raw, nil) // #nosec G107 -- attachment URLs are explicitly supplied by the caller.
 	if err != nil {
 		return nil, err

--- a/internal/notify/attachment.go
+++ b/internal/notify/attachment.go
@@ -1,0 +1,174 @@
+package notify
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type Attachment struct {
+	Source   string
+	Name     string
+	MIMEType string
+	Data     []byte
+}
+
+func ParseAttachments(rawValues []string) ([]Attachment, error) {
+	attachments := make([]Attachment, 0, len(rawValues))
+	for _, raw := range rawValues {
+		attachment, err := ParseAttachment(raw)
+		if err != nil {
+			return nil, err
+		}
+		attachments = append(attachments, attachment)
+	}
+	return attachments, nil
+}
+
+func ParseAttachment(raw string) (Attachment, error) {
+	source := strings.TrimSpace(raw)
+	if source == "" {
+		return Attachment{}, fmt.Errorf("empty attachment")
+	}
+
+	location, params := splitAttachmentParams(source)
+	name := strings.TrimSpace(params.Get("name"))
+	mimeType := strings.TrimSpace(params.Get("mime"))
+	if mimeType == "" {
+		mimeType = strings.TrimSpace(params.Get("mimetype"))
+	}
+
+	var data []byte
+	var err error
+	switch strings.ToLower(attachmentScheme(location)) {
+	case "http", "https":
+		data, err = readHTTPAttachment(location)
+	case "file":
+		data, location, err = readFileURLAttachment(location)
+	default:
+		data, err = os.ReadFile(location)
+	}
+	if err != nil {
+		return Attachment{}, err
+	}
+
+	if name == "" {
+		name = filepath.Base(location)
+	}
+	if name == "" || name == "." || name == string(filepath.Separator) {
+		name = "apprise-attachment"
+	}
+
+	if mimeType == "" {
+		mimeType = detectMIMEType(name, data)
+	}
+
+	return Attachment{
+		Source:   source,
+		Name:     name,
+		MIMEType: mimeType,
+		Data:     data,
+	}, nil
+}
+
+func (a Attachment) Base64() string {
+	return base64.StdEncoding.EncodeToString(a.Data)
+}
+
+func attachmentPayloads(attachments []Attachment) []map[string]any {
+	if len(attachments) == 0 {
+		return []map[string]any{}
+	}
+	payloads := make([]map[string]any, 0, len(attachments))
+	for i, attachment := range attachments {
+		filename := attachment.Name
+		if strings.TrimSpace(filename) == "" {
+			filename = fmt.Sprintf("file%03d.dat", i+1)
+		}
+		payloads = append(payloads, map[string]any{
+			"filename": filename,
+			"base64":   attachment.Base64(),
+			"mimetype": attachment.MIMEType,
+		})
+	}
+	return payloads
+}
+
+func splitAttachmentParams(raw string) (string, url.Values) {
+	parsed, err := url.Parse(raw)
+	if err == nil && parsed.Scheme != "" {
+		params := parsed.Query()
+		parsed.RawQuery = ""
+		return parsed.String(), params
+	}
+
+	parts := strings.SplitN(raw, "?", 2)
+	if len(parts) == 1 {
+		return raw, url.Values{}
+	}
+	params, err := url.ParseQuery(parts[1])
+	if err != nil {
+		return parts[0], url.Values{}
+	}
+	return parts[0], params
+}
+
+func attachmentScheme(raw string) string {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return ""
+	}
+	return parsed.Scheme
+}
+
+func readHTTPAttachment(raw string) ([]byte, error) {
+	resp, err := http.Get(raw)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, &HTTPStatusError{StatusCode: resp.StatusCode}
+	}
+	return io.ReadAll(resp.Body)
+}
+
+func readFileURLAttachment(raw string) ([]byte, string, error) {
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return nil, "", err
+	}
+	path := parsed.Path
+	if path == "" && parsed.Host != "" {
+		path = parsed.Host
+	}
+	data, err := os.ReadFile(path)
+	return data, path, err
+}
+
+func detectMIMEType(name string, data []byte) string {
+	if ext := filepath.Ext(name); ext != "" {
+		if value := mime.TypeByExtension(ext); value != "" {
+			if mediaType, _, err := mime.ParseMediaType(value); err == nil && mediaType != "" {
+				return mediaType
+			}
+			return value
+		}
+	}
+	if len(data) > 0 {
+		return http.DetectContentType(data)
+	}
+	return "application/octet-stream"
+}
+
+func escapeMultipartParam(value string) string {
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	return strings.ReplaceAll(value, `"`, `\"`)
+}

--- a/internal/notify/attachment.go
+++ b/internal/notify/attachment.go
@@ -13,8 +13,8 @@ import (
 	"time"
 )
 
-// DefaultMaxAttachmentBytes is the default cap used when fetching remote attachments.
-const DefaultMaxAttachmentBytes int64 = 25 * 1024 * 1024
+// DefaultMaxAttachmentBytes matches Python Apprise's default attachment cap.
+const DefaultMaxAttachmentBytes int64 = 1048576000
 
 var attachmentHTTPClient = &http.Client{Timeout: 30 * time.Second}
 

--- a/internal/notify/attachment.go
+++ b/internal/notify/attachment.go
@@ -10,7 +10,12 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
+
+const maxAttachmentBytes int64 = 25 * 1024 * 1024
+
+var attachmentHTTPClient = &http.Client{Timeout: 30 * time.Second}
 
 type Attachment struct {
 	Source   string
@@ -52,6 +57,7 @@ func ParseAttachment(raw string) (Attachment, error) {
 	case "file":
 		data, location, err = readFileURLAttachment(location)
 	default:
+		// #nosec G304 -- attachment paths are explicitly supplied by the caller.
 		data, err = os.ReadFile(location)
 	}
 	if err != nil {
@@ -128,7 +134,15 @@ func attachmentScheme(raw string) string {
 }
 
 func readHTTPAttachment(raw string) ([]byte, error) {
-	resp, err := http.Get(raw)
+	return readHTTPAttachmentWithClient(raw, attachmentHTTPClient, maxAttachmentBytes)
+}
+
+func readHTTPAttachmentWithClient(raw string, client *http.Client, maxBytes int64) ([]byte, error) {
+	req, err := http.NewRequest(http.MethodGet, raw, nil) // #nosec G107 -- attachment URLs are explicitly supplied by the caller.
+	if err != nil {
+		return nil, err
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -137,7 +151,14 @@ func readHTTPAttachment(raw string) ([]byte, error) {
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		return nil, &HTTPStatusError{StatusCode: resp.StatusCode}
 	}
-	return io.ReadAll(resp.Body)
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > maxBytes {
+		return nil, fmt.Errorf("attachment exceeds maximum size of %d bytes", maxBytes)
+	}
+	return data, nil
 }
 
 func readFileURLAttachment(raw string) ([]byte, string, error) {
@@ -149,6 +170,7 @@ func readFileURLAttachment(raw string) ([]byte, string, error) {
 	if path == "" && parsed.Host != "" {
 		path = parsed.Host
 	}
+	// #nosec G304 -- file:// attachment paths are explicitly supplied by the caller.
 	data, err := os.ReadFile(path)
 	return data, path, err
 }

--- a/internal/notify/attachment_parity_test.go
+++ b/internal/notify/attachment_parity_test.go
@@ -12,7 +12,6 @@ func TestAttachmentRequestParity(t *testing.T) {
 
 	localOne := writeAttachment(t, "report.txt", "attachment body\n")
 	localTwo := writeAttachment(t, "debug.log", "debug body\n")
-	remote := "https://files.example/report.txt?name=remote.txt"
 
 	tests := []struct {
 		name        string
@@ -23,11 +22,6 @@ func TestAttachmentRequestParity(t *testing.T) {
 			name:        "json local attachments",
 			rawURL:      "json://example.com/notify",
 			attachments: []string{localOne, localTwo},
-		},
-		{
-			name:        "json remote attachment",
-			rawURL:      "json://example.com/notify",
-			attachments: []string{remote},
 		},
 		{
 			name:        "xml local attachment",

--- a/internal/notify/attachment_parity_test.go
+++ b/internal/notify/attachment_parity_test.go
@@ -1,0 +1,88 @@
+package notify_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/unraid/apprise-go/internal/notify"
+	"github.com/unraid/apprise-go/internal/testutil"
+)
+
+func TestAttachmentRequestParity(t *testing.T) {
+	testutil.RequirePythonApprise(t)
+
+	localOne := writeAttachment(t, "report.txt", "attachment body\n")
+	localTwo := writeAttachment(t, "debug.log", "debug body\n")
+	remote := "https://files.example/report.txt?name=remote.txt"
+
+	tests := []struct {
+		name        string
+		rawURL      string
+		attachments []string
+	}{
+		{
+			name:        "json local attachments",
+			rawURL:      "json://example.com/notify",
+			attachments: []string{localOne, localTwo},
+		},
+		{
+			name:        "json remote attachment",
+			rawURL:      "json://example.com/notify",
+			attachments: []string{remote},
+		},
+		{
+			name:        "xml local attachment",
+			rawURL:      "xml://example.com/notify",
+			attachments: []string{localOne},
+		},
+		{
+			name:        "apprise api json local attachment",
+			rawURL:      "apprise://example.com/token?method=json",
+			attachments: []string{localOne},
+		},
+		{
+			name:        "apprise api form local attachment",
+			rawURL:      "apprise://example.com/token",
+			attachments: []string{localOne},
+		},
+		{
+			name:        "form local attachment",
+			rawURL:      "form://example.com/notify",
+			attachments: []string{localOne},
+		},
+		{
+			name:        "ntfy local attachment",
+			rawURL:      "ntfy://example.com/topic",
+			attachments: []string{localOne},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			body := "hello"
+			title := "Greeting"
+			pythonSpecs := testutil.CapturePythonRequestsWithAttachments(t, tt.rawURL, body, title, tt.attachments)
+
+			goSpecs := testutil.CaptureGoRequests(t, func() error {
+				attachments, err := notify.ParseAttachments(tt.attachments)
+				if err != nil {
+					return err
+				}
+				return notify.SendTargetURLWithAttachments(tt.rawURL, body, title, "text", notify.NotifyInfo, attachments)
+			})
+
+			testutil.AssertRequestSpecSequenceMatches(t, pythonSpecs, goSpecs)
+		})
+	}
+}
+
+func writeAttachment(t *testing.T, name, body string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write attachment fixture: %v", err)
+	}
+	return path
+}

--- a/internal/notify/attachment_parity_test.go
+++ b/internal/notify/attachment_parity_test.go
@@ -1,8 +1,6 @@
 package notify_test
 
 import (
-	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/unraid/apprise-go/internal/notify"
@@ -56,6 +54,11 @@ func TestAttachmentRequestParity(t *testing.T) {
 			rawURL:      "ntfy://example.com/topic",
 			attachments: []string{localOne},
 		},
+		{
+			name:        "ntfy multiple local attachments",
+			rawURL:      "ntfy://example.com/topic",
+			attachments: []string{localOne, localTwo},
+		},
 	}
 
 	for _, tt := range tests {
@@ -79,10 +82,5 @@ func TestAttachmentRequestParity(t *testing.T) {
 
 func writeAttachment(t *testing.T, name, body string) string {
 	t.Helper()
-
-	path := filepath.Join(t.TempDir(), name)
-	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
-		t.Fatalf("write attachment fixture: %v", err)
-	}
-	return path
+	return testutil.WriteAttachmentFixture(t, name, body)
 }

--- a/internal/notify/attachment_parity_test.go
+++ b/internal/notify/attachment_parity_test.go
@@ -1,6 +1,8 @@
 package notify_test
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/unraid/apprise-go/internal/notify"
@@ -12,16 +14,29 @@ func TestAttachmentRequestParity(t *testing.T) {
 
 	localOne := writeAttachment(t, "report.txt", "attachment body\n")
 	localTwo := writeAttachment(t, "debug.bin", "\x00\x01debug body\n")
+	remoteServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer remoteServer.Close()
+	remoteOne := remoteServer.URL + "/report.txt"
 
 	tests := []struct {
-		name        string
-		rawURL      string
-		attachments []string
+		name             string
+		rawURL           string
+		attachments      []string
+		compareFinalOnly bool
 	}{
 		{
 			name:        "json local attachments",
 			rawURL:      "json://example.com/notify",
 			attachments: []string{localOne, localTwo},
+		},
+		{
+			name:             "json remote attachment",
+			rawURL:           "json://example.com/notify",
+			attachments:      []string{remoteOne},
+			compareFinalOnly: true,
 		},
 		{
 			name:        "xml local attachment",
@@ -69,9 +84,21 @@ func TestAttachmentRequestParity(t *testing.T) {
 				return notify.SendTargetURLWithAttachments(tt.rawURL, body, title, "text", notify.NotifyInfo, attachments)
 			})
 
+			if tt.compareFinalOnly {
+				pythonSpecs = finalRequestSpec(t, pythonSpecs)
+				goSpecs = finalRequestSpec(t, goSpecs)
+			}
 			testutil.AssertRequestSpecSequenceMatches(t, pythonSpecs, goSpecs)
 		})
 	}
+}
+
+func finalRequestSpec(t *testing.T, specs []notify.RequestSpec) []notify.RequestSpec {
+	t.Helper()
+	if len(specs) == 0 {
+		t.Fatalf("no request specs captured")
+	}
+	return []notify.RequestSpec{specs[len(specs)-1]}
 }
 
 func writeAttachment(t *testing.T, name, body string) string {

--- a/internal/notify/attachment_parity_test.go
+++ b/internal/notify/attachment_parity_test.go
@@ -11,7 +11,7 @@ func TestAttachmentRequestParity(t *testing.T) {
 	testutil.RequirePythonApprise(t)
 
 	localOne := writeAttachment(t, "report.txt", "attachment body\n")
-	localTwo := writeAttachment(t, "debug.log", "debug body\n")
+	localTwo := writeAttachment(t, "debug.bin", "\x00\x01debug body\n")
 
 	tests := []struct {
 		name        string

--- a/internal/notify/attachment_test.go
+++ b/internal/notify/attachment_test.go
@@ -1,0 +1,35 @@
+package notify
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestReadHTTPAttachmentRejectsOversizeResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("12345"))
+	}))
+	defer server.Close()
+
+	_, err := readHTTPAttachmentWithClient(server.URL, server.Client(), 4)
+	if err == nil || !strings.Contains(err.Error(), "attachment exceeds maximum size") {
+		t.Fatalf("error = %v, want maximum size error", err)
+	}
+}
+
+func TestReadHTTPAttachmentAllowsMaxSizeResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("1234"))
+	}))
+	defer server.Close()
+
+	data, err := readHTTPAttachmentWithClient(server.URL, server.Client(), 4)
+	if err != nil {
+		t.Fatalf("read attachment: %v", err)
+	}
+	if string(data) != "1234" {
+		t.Fatalf("data = %q, want %q", string(data), "1234")
+	}
+}

--- a/internal/notify/form.go
+++ b/internal/notify/form.go
@@ -55,6 +55,11 @@ func NewFormTarget(target *ParsedURL) (*FormTarget, error) {
 		delete(payloadExtras, key)
 	}
 
+	attachAs, attachMulti, err := parseFormAttachAs(target.Query["attach-as"])
+	if err != nil {
+		return nil, err
+	}
+
 	return &FormTarget{
 		target:        target,
 		method:        method,
@@ -62,8 +67,8 @@ func NewFormTarget(target *ParsedURL) (*FormTarget, error) {
 		params:        cloneMap(target.QueryDel),
 		payloadExtras: payloadExtras,
 		payloadMap:    payloadMap,
-		attachAs:      parseFormAttachAs(target.Query["attach-as"]),
-		attachMulti:   formAttachAsMulti(target.Query["attach-as"]),
+		attachAs:      attachAs,
+		attachMulti:   attachMulti,
 	}, nil
 }
 
@@ -166,10 +171,7 @@ func (f *FormTarget) BuildRequestWithAttachments(body, title string, notifyType 
 		"User-Agent": "Apprise",
 		"Accept":     "*/*",
 	}
-	if f.method != "GET" && len(attachments) == 0 {
-		headers["Content-Type"] = contentType
-	}
-	if f.method != "GET" && len(attachments) > 0 {
+	if f.method != "GET" {
 		headers["Content-Type"] = contentType
 	}
 	for key, value := range f.headers {
@@ -224,21 +226,32 @@ func (f *FormTarget) buildMultipartPayload(payload map[string]string, attachment
 	return body.String(), writer.FormDataContentType(), nil
 }
 
-func parseFormAttachAs(raw string) string {
+func parseFormAttachAs(raw string) (string, bool, error) {
 	value := strings.TrimSpace(raw)
 	if value == "" {
-		return "file%02d"
+		return "file%02d", true, nil
 	}
-	if strings.ContainsAny(value, "*?+$:.%") {
-		replacer := strings.NewReplacer("*", "%02d", "?", "%02d", "+", "%02d", "$", "%02d", ":", "%02d", ".", "%02d", "%", "%02d")
-		return replacer.Replace(value)
+	if strings.Count(value, "%02d") > 1 {
+		return "", false, fmt.Errorf("attach-as supports only one placeholder")
 	}
-	return value
-}
+	if strings.Contains(value, "%02d") {
+		return value, true, nil
+	}
 
-func formAttachAsMulti(raw string) bool {
-	value := strings.TrimSpace(raw)
-	return value == "" || strings.ContainsAny(value, "*?+$:.%")
+	wildcard := -1
+	for i, ch := range value {
+		if !strings.ContainsRune("*?+$:.%", ch) {
+			continue
+		}
+		if wildcard >= 0 {
+			return "", false, fmt.Errorf("attach-as supports only one wildcard")
+		}
+		wildcard = i
+	}
+	if wildcard < 0 {
+		return value, false, nil
+	}
+	return value[:wildcard] + "%02d" + value[wildcard+1:], true, nil
 }
 
 func init() {

--- a/internal/notify/form.go
+++ b/internal/notify/form.go
@@ -1,7 +1,10 @@
 package notify
 
 import (
+	"bytes"
 	"fmt"
+	"mime/multipart"
+	"net/textproto"
 	"net/url"
 	"strings"
 )
@@ -22,6 +25,8 @@ type FormTarget struct {
 	params        map[string]string
 	payloadExtras map[string]string
 	payloadMap    map[string]string
+	attachAs      string
+	attachMulti   bool
 }
 
 func NewFormTarget(target *ParsedURL) (*FormTarget, error) {
@@ -57,11 +62,17 @@ func NewFormTarget(target *ParsedURL) (*FormTarget, error) {
 		params:        cloneMap(target.QueryDel),
 		payloadExtras: payloadExtras,
 		payloadMap:    payloadMap,
+		attachAs:      parseFormAttachAs(target.Query["attach-as"]),
+		attachMulti:   formAttachAsMulti(target.Query["attach-as"]),
 	}, nil
 }
 
 func (f *FormTarget) Send(body, title string, notifyType NotifyType) error {
-	spec, err := f.BuildRequest(body, title, notifyType)
+	return f.SendWithAttachments(body, title, notifyType, nil)
+}
+
+func (f *FormTarget) SendWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) error {
+	spec, err := f.BuildRequestWithAttachments(body, title, notifyType, attachments)
 	if err != nil {
 		return err
 	}
@@ -70,6 +81,10 @@ func (f *FormTarget) Send(body, title string, notifyType NotifyType) error {
 }
 
 func (f *FormTarget) BuildRequest(body, title string, notifyType NotifyType) (RequestSpec, error) {
+	return f.BuildRequestWithAttachments(body, title, notifyType, nil)
+}
+
+func (f *FormTarget) BuildRequestWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) (RequestSpec, error) {
 	payload := map[string]string{}
 
 	base := map[string]string{
@@ -122,12 +137,21 @@ func (f *FormTarget) BuildRequest(body, title string, notifyType NotifyType) (Re
 	}
 
 	bodyPayload := ""
+	contentType := "application/x-www-form-urlencoded"
 	if f.method != "GET" {
-		values := url.Values{}
-		for key, value := range payload {
-			values.Set(key, value)
+		if len(attachments) > 0 {
+			var err error
+			bodyPayload, contentType, err = f.buildMultipartPayload(payload, attachments)
+			if err != nil {
+				return RequestSpec{}, err
+			}
+		} else {
+			values := url.Values{}
+			for key, value := range payload {
+				values.Set(key, value)
+			}
+			bodyPayload = values.Encode()
 		}
-		bodyPayload = values.Encode()
 	}
 
 	if f.method != "GET" && len(f.params) > 0 {
@@ -142,8 +166,11 @@ func (f *FormTarget) BuildRequest(body, title string, notifyType NotifyType) (Re
 		"User-Agent": "Apprise",
 		"Accept":     "*/*",
 	}
-	if f.method != "GET" {
-		headers["Content-Type"] = "application/x-www-form-urlencoded"
+	if f.method != "GET" && len(attachments) == 0 {
+		headers["Content-Type"] = contentType
+	}
+	if f.method != "GET" && len(attachments) > 0 {
+		headers["Content-Type"] = contentType
 	}
 	for key, value := range f.headers {
 		headers[key] = value
@@ -162,6 +189,56 @@ func (f *FormTarget) BuildRequest(body, title string, notifyType NotifyType) (Re
 		Headers: headers,
 		Body:    bodyPayload,
 	}, nil
+}
+
+func (f *FormTarget) buildMultipartPayload(payload map[string]string, attachments []Attachment) (string, string, error) {
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	for key, value := range payload {
+		if err := writer.WriteField(key, value); err != nil {
+			return "", "", err
+		}
+	}
+	for i, attachment := range attachments {
+		fieldName := f.attachAs
+		if f.attachMulti {
+			fieldName = fmt.Sprintf(f.attachAs, i+1)
+		}
+		if strings.TrimSpace(fieldName) == "" {
+			fieldName = "file"
+		}
+		header := textproto.MIMEHeader{}
+		header.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"; filename="%s"`, escapeMultipartParam(fieldName), escapeMultipartParam(attachment.Name)))
+		header.Set("Content-Type", attachment.MIMEType)
+		part, err := writer.CreatePart(header)
+		if err != nil {
+			return "", "", err
+		}
+		if _, err := part.Write(attachment.Data); err != nil {
+			return "", "", err
+		}
+	}
+	if err := writer.Close(); err != nil {
+		return "", "", err
+	}
+	return body.String(), writer.FormDataContentType(), nil
+}
+
+func parseFormAttachAs(raw string) string {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return "file%02d"
+	}
+	if strings.ContainsAny(value, "*?+$:.%") {
+		replacer := strings.NewReplacer("*", "%02d", "?", "%02d", "+", "%02d", "$", "%02d", ":", "%02d", ".", "%02d", "%", "%02d")
+		return replacer.Replace(value)
+	}
+	return value
+}
+
+func formAttachAsMulti(raw string) bool {
+	value := strings.TrimSpace(raw)
+	return value == "" || strings.ContainsAny(value, "*?+$:.%")
 }
 
 func init() {

--- a/internal/notify/form_test.go
+++ b/internal/notify/form_test.go
@@ -1,0 +1,40 @@
+package notify
+
+import "testing"
+
+func TestParseFormAttachAsRejectsMultipleWildcards(t *testing.T) {
+	_, _, err := parseFormAttachAs("file.$")
+	if err == nil {
+		t.Fatalf("expected multi-wildcard attach-as to fail")
+	}
+}
+
+func TestParseFormAttachAsExpandsSingleWildcard(t *testing.T) {
+	attachAs, multi, err := parseFormAttachAs("file*")
+	if err != nil {
+		t.Fatalf("parse attach-as: %v", err)
+	}
+	if attachAs != "file%02d" || !multi {
+		t.Fatalf("attachAs=%q multi=%v, want file%%02d true", attachAs, multi)
+	}
+}
+
+func TestParseFormAttachAsAllowsExplicitPlaceholder(t *testing.T) {
+	attachAs, multi, err := parseFormAttachAs("upload-%02d.txt")
+	if err != nil {
+		t.Fatalf("parse attach-as: %v", err)
+	}
+	if attachAs != "upload-%02d.txt" || !multi {
+		t.Fatalf("attachAs=%q multi=%v, want upload-%%02d.txt true", attachAs, multi)
+	}
+}
+
+func TestNewFormTargetRejectsInvalidAttachAs(t *testing.T) {
+	parsed, err := ParseURL("form://example.com/notify?attach-as=file.$")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	if _, err := NewFormTarget(parsed); err == nil {
+		t.Fatalf("expected invalid attach-as to fail")
+	}
+}

--- a/internal/notify/json.go
+++ b/internal/notify/json.go
@@ -43,7 +43,11 @@ func NewJSONTarget(target *ParsedURL) (*JSONTarget, error) {
 }
 
 func (j *JSONTarget) Send(body, title string, notifyType NotifyType) error {
-	spec, err := j.BuildRequest(body, title, notifyType)
+	return j.SendWithAttachments(body, title, notifyType, nil)
+}
+
+func (j *JSONTarget) SendWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) error {
+	spec, err := j.BuildRequestWithAttachments(body, title, notifyType, attachments)
 	if err != nil {
 		return err
 	}
@@ -52,11 +56,15 @@ func (j *JSONTarget) Send(body, title string, notifyType NotifyType) error {
 }
 
 func (j *JSONTarget) BuildRequest(body, title string, notifyType NotifyType) (RequestSpec, error) {
+	return j.BuildRequestWithAttachments(body, title, notifyType, nil)
+}
+
+func (j *JSONTarget) BuildRequestWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) (RequestSpec, error) {
 	payload := map[string]any{
 		"version":     "1.0",
 		"title":       title,
 		"message":     body,
-		"attachments": []any{},
+		"attachments": attachmentPayloads(attachments),
 		"type":        string(notifyType),
 	}
 

--- a/internal/notify/mailto_target.go
+++ b/internal/notify/mailto_target.go
@@ -2,6 +2,7 @@ package notify
 
 import (
 	"crypto/tls"
+	"encoding/base64"
 	"fmt"
 	"net"
 	"net/mail"
@@ -204,6 +205,10 @@ func parseMailtoEmailList(inputs []string) []string {
 }
 
 func (m *MailtoTarget) Send(body, title string, notifyType NotifyType) error {
+	return m.SendWithAttachments(body, title, notifyType, nil)
+}
+
+func (m *MailtoTarget) SendWithAttachments(body, title string, _ NotifyType, attachments []Attachment) error {
 	client, err := m.connect()
 	if err != nil {
 		return err
@@ -212,7 +217,7 @@ func (m *MailtoTarget) Send(body, title string, notifyType NotifyType) error {
 		_ = client.Quit()
 	}()
 
-	messages, err := m.buildMessages(body, title)
+	messages, err := m.buildMessagesWithAttachments(body, title, attachments)
 	if err != nil {
 		return err
 	}
@@ -304,6 +309,10 @@ func (m *MailtoTarget) authenticate(client *smtp.Client) (*smtp.Client, error) {
 }
 
 func (m *MailtoTarget) buildMessages(body, title string) ([]mailtoMessage, error) {
+	return m.buildMessagesWithAttachments(body, title, nil)
+}
+
+func (m *MailtoTarget) buildMessagesWithAttachments(body, title string, attachments []Attachment) ([]mailtoMessage, error) {
 	if len(m.targets) == 0 {
 		return nil, fmt.Errorf("missing targets")
 	}
@@ -327,6 +336,9 @@ func (m *MailtoTarget) buildMessages(body, title string) ([]mailtoMessage, error
 		reply := filterEmailList(m.replyTo, nil, target)
 
 		contentTypeHeader, transferHeader, messageBody := buildMailtoBody(body, format)
+		if len(attachments) > 0 {
+			contentTypeHeader, transferHeader, messageBody = buildMailtoMixedBody(contentTypeHeader, transferHeader, messageBody, attachments)
+		}
 		headers := []string{
 			fmt.Sprintf("Subject: %s", subject),
 			fmt.Sprintf("From: %s", fromHeader),
@@ -462,6 +474,57 @@ func buildMultipartAlternative(boundary, plain, html string) string {
 		html,
 		"--" + boundary + "--",
 		"",
+	}
+	return strings.Join(lines, "\r\n")
+}
+
+func buildMailtoMixedBody(contentTypeHeader, transferHeader, messageBody string, attachments []Attachment) (string, string, string) {
+	boundary := fmt.Sprintf("===============%d==", time.Now().UnixNano())
+	lines := []string{
+		"--" + boundary,
+		fmt.Sprintf("Content-Type: %s", contentTypeHeader),
+		"MIME-Version: 1.0",
+	}
+	if transferHeader != "" {
+		lines = append(lines, fmt.Sprintf("Content-Transfer-Encoding: %s", transferHeader))
+	}
+	lines = append(lines, "", messageBody)
+
+	for i, attachment := range attachments {
+		filename := attachment.Name
+		if strings.TrimSpace(filename) == "" {
+			filename = fmt.Sprintf("file%03d.dat", i+1)
+		}
+		lines = append(lines,
+			"--"+boundary,
+			fmt.Sprintf("Content-Type: %s", attachment.MIMEType),
+			"MIME-Version: 1.0",
+			"Content-Transfer-Encoding: base64",
+			fmt.Sprintf("Content-Disposition: attachment; filename=\"%s\"", escapeMailtoHeaderParam(filename)),
+			"",
+			wrapBase64(base64.StdEncoding.EncodeToString(attachment.Data)),
+		)
+	}
+	lines = append(lines, "--"+boundary+"--", "")
+	return fmt.Sprintf("multipart/mixed; boundary=\"%s\"", boundary), "", strings.Join(lines, "\r\n")
+}
+
+func escapeMailtoHeaderParam(value string) string {
+	value = strings.ReplaceAll(value, "\\", "\\\\")
+	return strings.ReplaceAll(value, "\"", "\\\"")
+}
+
+func wrapBase64(value string) string {
+	if len(value) <= 76 {
+		return value
+	}
+	lines := make([]string, 0, (len(value)/76)+1)
+	for len(value) > 76 {
+		lines = append(lines, value[:76])
+		value = value[76:]
+	}
+	if value != "" {
+		lines = append(lines, value)
 	}
 	return strings.Join(lines, "\r\n")
 }

--- a/internal/notify/mailto_target.go
+++ b/internal/notify/mailto_target.go
@@ -308,10 +308,6 @@ func (m *MailtoTarget) authenticate(client *smtp.Client) (*smtp.Client, error) {
 	return client, nil
 }
 
-func (m *MailtoTarget) buildMessages(body, title string) ([]mailtoMessage, error) {
-	return m.buildMessagesWithAttachments(body, title, nil)
-}
-
 func (m *MailtoTarget) buildMessagesWithAttachments(body, title string, attachments []Attachment) ([]mailtoMessage, error) {
 	if len(m.targets) == 0 {
 		return nil, fmt.Errorf("missing targets")

--- a/internal/notify/ntfy.go
+++ b/internal/notify/ntfy.go
@@ -109,13 +109,44 @@ func NewNtfyTarget(target *ParsedURL) (*NtfyTarget, error) {
 }
 
 func (n *NtfyTarget) BuildRequest(body, title string, notifyType NotifyType) (RequestSpec, error) {
+	requests, err := n.BuildRequestsWithAttachments(body, title, notifyType, nil)
+	if err != nil {
+		return RequestSpec{}, err
+	}
+	if len(requests) == 0 {
+		return RequestSpec{}, fmt.Errorf("no requests")
+	}
+	return requests[0], nil
+}
+
+func (n *NtfyTarget) BuildRequestsWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) ([]RequestSpec, error) {
 	if len(n.topics) == 0 {
-		return RequestSpec{}, fmt.Errorf("no topics")
+		return nil, fmt.Errorf("no topics")
+	}
+
+	if len(attachments) > 0 {
+		specs := []RequestSpec{}
+		for _, topic := range n.topics {
+			for i, attachment := range attachments {
+				sendBody := ""
+				sendTitle := ""
+				if i == 0 {
+					sendBody = body
+					sendTitle = title
+				}
+				spec, err := n.buildAttachmentRequest(topic, attachment, sendBody, sendTitle, notifyType)
+				if err != nil {
+					return nil, err
+				}
+				specs = append(specs, spec)
+			}
+		}
+		return specs, nil
 	}
 
 	urlStr, err := n.notifyURL()
 	if err != nil {
-		return RequestSpec{}, err
+		return nil, err
 	}
 
 	payload := map[string]any{
@@ -132,13 +163,24 @@ func (n *NtfyTarget) BuildRequest(body, title string, notifyType NotifyType) (Re
 
 	data, err := json.Marshal(payload)
 	if err != nil {
-		return RequestSpec{}, err
+		return nil, err
 	}
 
+	headers := n.headers(notifyType)
+	headers["Content-Type"] = "application/json"
+
+	return []RequestSpec{{
+		Method:  "POST",
+		URL:     urlStr,
+		Headers: headers,
+		Body:    string(data),
+	}}, nil
+}
+
+func (n *NtfyTarget) headers(notifyType NotifyType) map[string]string {
 	headers := map[string]string{
-		"User-Agent":   "Apprise",
-		"Accept":       "*/*",
-		"Content-Type": "application/json",
+		"User-Agent": "Apprise",
+		"Accept":     "*/*",
 	}
 
 	if n.mode == NtfyModePrivate {
@@ -183,22 +225,53 @@ func (n *NtfyTarget) BuildRequest(body, title string, notifyType NotifyType) (Re
 	if n.actions != "" {
 		headers["X-Actions"] = n.actions
 	}
+	return headers
+}
+
+func (n *NtfyTarget) buildAttachmentRequest(topic string, attachment Attachment, body, title string, notifyType NotifyType) (RequestSpec, error) {
+	urlStr, err := n.attachmentURL(topic)
+	if err != nil {
+		return RequestSpec{}, err
+	}
+
+	u, err := url.Parse(urlStr)
+	if err != nil {
+		return RequestSpec{}, err
+	}
+	values := u.Query()
+	values.Set("filename", attachment.Name)
+	if title != "" {
+		values.Set("title", title)
+	}
+	if body != "" {
+		values.Set("message", body)
+	}
+	u.RawQuery = values.Encode()
 
 	return RequestSpec{
 		Method:  "POST",
-		URL:     urlStr,
-		Headers: headers,
-		Body:    string(data),
+		URL:     u.String(),
+		Headers: n.headers(notifyType),
+		Body:    string(attachment.Data),
 	}, nil
 }
 
 func (n *NtfyTarget) Send(body, title string, notifyType NotifyType) error {
-	spec, err := n.BuildRequest(body, title, notifyType)
+	return n.SendWithAttachments(body, title, notifyType, nil)
+}
+
+func (n *NtfyTarget) SendWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) error {
+	specs, err := n.BuildRequestsWithAttachments(body, title, notifyType, attachments)
 	if err != nil {
 		return err
 	}
 
-	return SendRequest(spec)
+	for _, spec := range specs {
+		if err := SendRequest(spec); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (n *NtfyTarget) notifyURL() (string, error) {
@@ -221,6 +294,27 @@ func (n *NtfyTarget) notifyURL() (string, error) {
 	}
 
 	u := url.URL{Scheme: scheme, Host: host, Path: "/"}
+	return u.String(), nil
+}
+
+func (n *NtfyTarget) attachmentURL(topic string) (string, error) {
+	if n.mode == NtfyModeCloud {
+		u := url.URL{Scheme: "https", Host: "ntfy.sh", Path: "/" + topic}
+		return u.String(), nil
+	}
+
+	scheme := "http"
+	if strings.ToLower(n.target.Scheme) == "ntfys" {
+		scheme = "https"
+	}
+	host := n.target.Host
+	if host == "" {
+		return "", fmt.Errorf("missing host")
+	}
+	if n.target.Port != 0 {
+		host = fmt.Sprintf("%s:%d", host, n.target.Port)
+	}
+	u := url.URL{Scheme: scheme, Host: host, Path: "/" + topic}
 	return u.String(), nil
 }
 

--- a/internal/notify/target.go
+++ b/internal/notify/target.go
@@ -14,6 +14,8 @@ type AttachmentSender interface {
 	SendWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) error
 }
 
+var ErrAttachmentsUnsupported = errors.New("attachments unsupported by target")
+
 type buildTargetFunc func(*ParsedURL) (Sender, error)
 
 type UnsupportedSchemaError struct {
@@ -59,10 +61,18 @@ func SendTargetURLWithAttachments(rawURL, body, title, inputFormat string, notif
 	if err != nil {
 		return err
 	}
-	if sender, ok := target.(AttachmentSender); ok {
-		return sender.SendWithAttachments(sendBody, title, notifyType, attachments)
+	return DispatchSend(target, sendBody, title, notifyType, attachments)
+}
+
+func DispatchSend(target Sender, body, title string, notifyType NotifyType, attachments []Attachment) error {
+	if len(attachments) == 0 {
+		return target.Send(body, title, notifyType)
 	}
-	return target.Send(sendBody, title, notifyType)
+	sender, ok := target.(AttachmentSender)
+	if !ok {
+		return ErrAttachmentsUnsupported
+	}
+	return sender.SendWithAttachments(body, title, notifyType, attachments)
 }
 
 func TargetSchemaName(schema string) string {

--- a/internal/notify/target.go
+++ b/internal/notify/target.go
@@ -10,6 +10,10 @@ type Sender interface {
 	Send(body, title string, notifyType NotifyType) error
 }
 
+type AttachmentSender interface {
+	SendWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) error
+}
+
 type buildTargetFunc func(*ParsedURL) (Sender, error)
 
 type UnsupportedSchemaError struct {
@@ -37,6 +41,10 @@ func NewTarget(parsed *ParsedURL) (Sender, error) {
 }
 
 func SendTargetURL(rawURL, body, title, inputFormat string, notifyType NotifyType) error {
+	return SendTargetURLWithAttachments(rawURL, body, title, inputFormat, notifyType, nil)
+}
+
+func SendTargetURLWithAttachments(rawURL, body, title, inputFormat string, notifyType NotifyType, attachments []Attachment) error {
 	parsed, err := ParseURL(rawURL)
 	if err != nil {
 		return err
@@ -50,6 +58,9 @@ func SendTargetURL(rawURL, body, title, inputFormat string, notifyType NotifyTyp
 	target, err := NewTarget(parsed)
 	if err != nil {
 		return err
+	}
+	if sender, ok := target.(AttachmentSender); ok {
+		return sender.SendWithAttachments(sendBody, title, notifyType, attachments)
 	}
 	return target.Send(sendBody, title, notifyType)
 }

--- a/internal/notify/target_test.go
+++ b/internal/notify/target_test.go
@@ -1,6 +1,9 @@
 package notify
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
 
 func TestTargetBuildersCoverSupportedSchemas(t *testing.T) {
 	for _, schema := range SupportedSchemas() {
@@ -8,4 +11,36 @@ func TestTargetBuildersCoverSupportedSchemas(t *testing.T) {
 			t.Fatalf("missing target builder for supported schema %s", schema)
 		}
 	}
+}
+
+func TestDispatchSendRejectsUnsupportedAttachments(t *testing.T) {
+	target := &recordingSender{}
+
+	err := DispatchSend(target, "body", "title", NotifyInfo, []Attachment{{Name: "report.txt"}})
+	if !errors.Is(err, ErrAttachmentsUnsupported) {
+		t.Fatalf("error = %v, want ErrAttachmentsUnsupported", err)
+	}
+	if target.sent {
+		t.Fatalf("target Send called despite unsupported attachments")
+	}
+}
+
+func TestDispatchSendWithoutAttachmentsUsesSender(t *testing.T) {
+	target := &recordingSender{}
+
+	if err := DispatchSend(target, "body", "title", NotifyInfo, nil); err != nil {
+		t.Fatalf("dispatch send: %v", err)
+	}
+	if !target.sent {
+		t.Fatalf("target Send was not called")
+	}
+}
+
+type recordingSender struct {
+	sent bool
+}
+
+func (r *recordingSender) Send(body, title string, notifyType NotifyType) error {
+	r.sent = true
+	return nil
 }

--- a/internal/notify/xml.go
+++ b/internal/notify/xml.go
@@ -93,7 +93,11 @@ func NewXMLTarget(target *ParsedURL) (*XMLTarget, error) {
 }
 
 func (x *XMLTarget) Send(body, title string, notifyType NotifyType) error {
-	spec, err := x.BuildRequest(body, title, notifyType)
+	return x.SendWithAttachments(body, title, notifyType, nil)
+}
+
+func (x *XMLTarget) SendWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) error {
+	spec, err := x.BuildRequestWithAttachments(body, title, notifyType, attachments)
 	if err != nil {
 		return err
 	}
@@ -102,6 +106,10 @@ func (x *XMLTarget) Send(body, title string, notifyType NotifyType) error {
 }
 
 func (x *XMLTarget) BuildRequest(body, title string, notifyType NotifyType) (RequestSpec, error) {
+	return x.BuildRequestWithAttachments(body, title, notifyType, nil)
+}
+
+func (x *XMLTarget) BuildRequestWithAttachments(body, title string, notifyType NotifyType, attachments []Attachment) (RequestSpec, error) {
 	payloadBase := []struct {
 		key   string
 		value string
@@ -132,7 +140,7 @@ func (x *XMLTarget) BuildRequest(body, title string, notifyType NotifyType) (Req
 
 	payload := strings.ReplaceAll(xmlTemplate, "{{XSD_URL}}", xsdAttr)
 	payload = strings.ReplaceAll(payload, "{{CORE}}", strings.Join(entries, ""))
-	payload = strings.ReplaceAll(payload, "{{ATTACHMENTS}}", "")
+	payload = strings.ReplaceAll(payload, "{{ATTACHMENTS}}", buildXMLAttachments(attachments))
 
 	scheme := "http"
 	if strings.ToLower(x.target.Scheme) == "xmls" {
@@ -175,6 +183,26 @@ func (x *XMLTarget) BuildRequest(body, title string, notifyType NotifyType) (Req
 		Headers: headers,
 		Body:    payload,
 	}, nil
+}
+
+func buildXMLAttachments(attachments []Attachment) string {
+	if len(attachments) == 0 {
+		return ""
+	}
+	entries := make([]string, 0, len(attachments))
+	for i, attachment := range attachments {
+		filename := attachment.Name
+		if strings.TrimSpace(filename) == "" {
+			filename = fmt.Sprintf("file%03d.dat", i+1)
+		}
+		entries = append(entries, fmt.Sprintf(
+			"<Attachment filename=\"%s\" mimetype=\"%s\">%s</Attachment>",
+			escapeXML(filename),
+			escapeXML(attachment.MIMEType),
+			attachment.Base64(),
+		))
+	}
+	return "<Attachments format=\"base64\">" + strings.Join(entries, "") + "</Attachments>"
 }
 
 func sanitizeXMLKey(value string) string {

--- a/internal/parity/mailto_parity_test.go
+++ b/internal/parity/mailto_parity_test.go
@@ -38,6 +38,15 @@ type normalizedSMTP struct {
 }
 
 func TestMailtoSMTPParity(t *testing.T) {
+	testMailtoSMTPParity(t, nil)
+}
+
+func TestMailtoSMTPAttachmentParity(t *testing.T) {
+	attachment := testutil.WriteAttachmentFixture(t, "report.txt", "attachment body\n")
+	testMailtoSMTPParity(t, []string{attachment})
+}
+
+func testMailtoSMTPParity(t *testing.T, attachmentPaths []string) {
 	capture := testutil.StartSMTPCapture(t)
 	defer func() {
 		_ = capture.Close()
@@ -61,7 +70,11 @@ func TestMailtoSMTPParity(t *testing.T) {
 	t.Setenv("PYTHONPATH", appriseRoot)
 
 	script := filepath.Join(testutil.RepoRoot(t), "internal", "testutil", "scripts", "capture_smtp.py")
-	stdout, stderr, err := testutil.RunPythonScript(t, script, "--url", url, "--body", body, "--title", title)
+	args := []string{"--url", url, "--body", body, "--title", title}
+	for _, attachment := range attachmentPaths {
+		args = append(args, "--attach", attachment)
+	}
+	stdout, stderr, err := testutil.RunPythonScript(t, script, args...)
 	if err != nil {
 		t.Fatalf("python smtp send failed: %v (stderr: %s)", err, strings.TrimSpace(stderr))
 	}
@@ -90,7 +103,11 @@ func TestMailtoSMTPParity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build mailto target: %v", err)
 	}
-	if err := target.Send(body, title, notify.NotifyInfo); err != nil {
+	attachments, err := notify.ParseAttachments(attachmentPaths)
+	if err != nil {
+		t.Fatalf("parse attachments: %v", err)
+	}
+	if err := target.SendWithAttachments(body, title, notify.NotifyInfo, attachments); err != nil {
 		t.Fatalf("go mailto send failed: %v", err)
 	}
 
@@ -273,6 +290,14 @@ func decodeSMTPPartBody(t *testing.T, header mail.Header, body io.Reader) string
 	raw, err := io.ReadAll(body)
 	if err != nil {
 		t.Fatalf("read smtp part body failed: %v", err)
+	}
+
+	contentType := header.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err == nil && strings.HasPrefix(strings.ToLower(mediaType), "multipart/") {
+		if boundary := params["boundary"]; boundary != "" {
+			return decodeMultipartBody(t, boundary, raw)
+		}
 	}
 
 	encoding := strings.ToLower(strings.TrimSpace(header.Get("Content-Transfer-Encoding")))

--- a/internal/testutil/apprise_source.go
+++ b/internal/testutil/apprise_source.go
@@ -9,6 +9,13 @@ import (
 func AppriseSourceRoot(t *testing.T) string {
 	t.Helper()
 
+	if override := os.Getenv("APPRISE_SOURCE_ROOT"); override != "" {
+		if fileExists(filepath.Join(override, "pyproject.toml")) {
+			return override
+		}
+		t.Fatalf("APPRISE_SOURCE_ROOT does not point to an Apprise source repo: %s", override)
+	}
+
 	root := RepoRoot(t)
 	candidate := filepath.Clean(filepath.Join(root, "..", "apprise"))
 

--- a/internal/testutil/attachments.go
+++ b/internal/testutil/attachments.go
@@ -1,0 +1,17 @@
+package testutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func WriteAttachmentFixture(t *testing.T, name, body string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write attachment fixture: %v", err)
+	}
+	return path
+}

--- a/internal/testutil/request_compare.go
+++ b/internal/testutil/request_compare.go
@@ -1,7 +1,11 @@
 package testutil
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
+	"mime"
+	"mime/multipart"
 	"net/url"
 	"reflect"
 	"sort"
@@ -88,6 +92,10 @@ func assertRequestSpecMatches(t *testing.T, pythonSpec, goSpec notify.RequestSpe
 		assertRequestQueryEqual(t, pythonBody, goBody)
 		return
 	}
+	if shouldCompareRequestMultipart(pythonHeaders) {
+		assertRequestMultipartEqual(t, pythonSpec, goSpec)
+		return
+	}
 
 	if pythonBody != goBody {
 		t.Fatalf("body mismatch: python=%s go=%s", pythonBody, goBody)
@@ -102,7 +110,7 @@ func NormalizeRequestHeaders(headers map[string]string) map[string]string {
 			continue
 		}
 		if _, keep := requestHeaderKeep[lower]; keep || strings.HasPrefix(lower, "x-") {
-			normalized[lower] = normalizeAppriseURL(value)
+			normalized[lower] = normalizeRequestHeaderValue(lower, value)
 		}
 	}
 
@@ -118,6 +126,16 @@ func NormalizeRequestHeaders(headers map[string]string) map[string]string {
 	}
 
 	return ordered
+}
+
+func normalizeRequestHeaderValue(key, value string) string {
+	if key == "content-type" {
+		mediaType, _, err := mime.ParseMediaType(value)
+		if err == nil && strings.HasPrefix(strings.ToLower(mediaType), "multipart/") {
+			return strings.ToLower(mediaType)
+		}
+	}
+	return normalizeAppriseURL(value)
 }
 
 func normalizeRequestBody(spec notify.RequestSpec) string {
@@ -142,6 +160,11 @@ func shouldCompareRequestForm(headers map[string]string, body string) bool {
 		return false
 	}
 	return strings.Contains(body, "=")
+}
+
+func shouldCompareRequestMultipart(headers map[string]string) bool {
+	contentType := strings.ToLower(headers["content-type"])
+	return strings.Contains(contentType, "multipart/form-data")
 }
 
 func shouldCompareRequestBodyAsJSON(pythonBody, goBody string) bool {
@@ -197,6 +220,70 @@ func assertRequestQueryEqual(t *testing.T, pythonBody, goBody string) {
 	if pythonNormalized.Encode() != goNormalized.Encode() {
 		t.Fatalf("query mismatch: python=%s go=%s", pythonNormalized.Encode(), goNormalized.Encode())
 	}
+}
+
+func assertRequestMultipartEqual(t *testing.T, pythonSpec, goSpec notify.RequestSpec) {
+	t.Helper()
+
+	pythonParts := normalizeMultipartParts(t, pythonSpec)
+	goParts := normalizeMultipartParts(t, goSpec)
+	if !reflect.DeepEqual(pythonParts, goParts) {
+		t.Fatalf("multipart mismatch: python=%v go=%v", pythonParts, goParts)
+	}
+}
+
+func normalizeMultipartParts(t *testing.T, spec notify.RequestSpec) []map[string]string {
+	t.Helper()
+
+	contentType := spec.Headers["content-type"]
+	if contentType == "" {
+		contentType = spec.Headers["Content-Type"]
+	}
+	_, params, err := mime.ParseMediaType(contentType)
+	if err != nil || params["boundary"] == "" {
+		t.Fatalf("parse multipart content-type: %v headers=%v", err, spec.Headers)
+	}
+
+	reader := multipart.NewReader(bytes.NewReader([]byte(spec.Body)), params["boundary"])
+	parts := []map[string]string{}
+	for {
+		part, err := reader.NextPart()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatalf("read multipart part: %v", err)
+		}
+		data, err := io.ReadAll(part)
+		if err != nil {
+			t.Fatalf("read multipart data: %v", err)
+		}
+		parts = append(parts, map[string]string{
+			"name":     part.FormName(),
+			"filename": part.FileName(),
+			"type":     normalizeMultipartContentType(part.Header.Get("Content-Type")),
+			"body":     string(data),
+		})
+	}
+
+	sort.Slice(parts, func(i, j int) bool {
+		if parts[i]["name"] != parts[j]["name"] {
+			return parts[i]["name"] < parts[j]["name"]
+		}
+		if parts[i]["filename"] != parts[j]["filename"] {
+			return parts[i]["filename"] < parts[j]["filename"]
+		}
+		return parts[i]["body"] < parts[j]["body"]
+	})
+	return parts
+}
+
+func normalizeMultipartContentType(value string) string {
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return strings.ToLower(strings.TrimSpace(value))
+	}
+	return strings.ToLower(mediaType)
 }
 
 func normalizeRequestQueryValues(values url.Values) url.Values {

--- a/internal/testutil/request_compare.go
+++ b/internal/testutil/request_compare.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"io"
 	"mime"
 	"mime/multipart"
@@ -248,7 +249,7 @@ func normalizeMultipartParts(t *testing.T, spec notify.RequestSpec) []map[string
 	parts := []map[string]string{}
 	for {
 		part, err := reader.NextPart()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		}
 		if err != nil {

--- a/internal/testutil/request_spec.go
+++ b/internal/testutil/request_spec.go
@@ -38,16 +38,33 @@ func CapturePythonRequestsWithFormat(t *testing.T, url, body, title, bodyFormat 
 func CapturePythonRequestsWithFormatAndTypeResult(t *testing.T, url, body, title, bodyFormat string, notifyType notify.NotifyType) ([]notify.RequestSpec, *bool) {
 	t.Helper()
 
+	return CapturePythonRequestsWithFormatTypeAndAttachmentsResult(t, url, body, title, bodyFormat, notifyType, nil)
+}
+
+func CapturePythonRequestsWithAttachments(t *testing.T, url, body, title string, attachments []string) []notify.RequestSpec {
+	t.Helper()
+
+	specs, _ := CapturePythonRequestsWithFormatTypeAndAttachmentsResult(t, url, body, title, "", notify.NotifyInfo, attachments)
+	return specs
+}
+
+func CapturePythonRequestsWithFormatTypeAndAttachmentsResult(t *testing.T, url, body, title, bodyFormat string, notifyType notify.NotifyType, attachments []string) ([]notify.RequestSpec, *bool) {
+	t.Helper()
+
 	script := filepath.Join(RepoRoot(t), "internal", "testutil", "scripts", "capture_request.py")
-	stdout, stderr, err := RunPythonScript(
-		t,
-		script,
+	args := []string{
 		"--url", url,
 		"--body", body,
 		"--title", title,
 		"--type", string(notifyType),
-		"--body-format", bodyFormat,
-	)
+	}
+	if bodyFormat != "" {
+		args = append(args, "--body-format", bodyFormat)
+	}
+	for _, attachment := range attachments {
+		args = append(args, "--attach", attachment)
+	}
+	stdout, stderr, err := RunPythonScript(t, script, args...)
 	if err != nil {
 		t.Fatalf("capture request failed: %v (stderr: %s)", err, strings.TrimSpace(stderr))
 	}

--- a/internal/testutil/scripts/capture_request.py
+++ b/internal/testutil/scripts/capture_request.py
@@ -94,7 +94,7 @@ DROP_HEADERS = {"x-apprise-id", "x-apprise-recursion-count"}
 KEEP_HEADERS = {"content-type", "accept", "accepts", "authorization"}
 
 BLUESKY_CREATED_AT = "2024-01-01T00:00:00Z"
-CACHE_VERSION = 9
+CACHE_VERSION = 10
 CACHE_ENV = "APPRISE_CAPTURE_CACHE"
 CACHE_DIR_ENV = "APPRISE_CAPTURE_CACHE_DIR"
 CACHE_SUBDIR = ".tmp/pycapture"
@@ -163,7 +163,7 @@ def apprise_git_sha():
     return output.decode("utf-8", "replace").strip()
 
 
-def cache_key(url, body, title, notify_type, body_format):
+def cache_key(url, body, title, notify_type, body_format, attachments):
     notify_name = notify_type.name if hasattr(notify_type, "name") else str(notify_type)
     try:
         import apprise as apprise_module
@@ -178,6 +178,7 @@ def cache_key(url, body, title, notify_type, body_format):
         "title": title,
         "notify_type": notify_name,
         "body_format": body_format,
+        "attachments": attachments,
         "apprise_version": apprise_version,
         "apprise_sha": apprise_git_sha(),
         "python_version": sys.version,
@@ -204,10 +205,10 @@ def cache_key(url, body, title, notify_type, body_format):
     return digest
 
 
-def load_cache(url, body, title, notify_type, body_format):
+def load_cache(url, body, title, notify_type, body_format, attachments):
     if not cache_enabled():
         return None, None
-    digest = cache_key(url, body, title, notify_type, body_format)
+    digest = cache_key(url, body, title, notify_type, body_format, attachments)
     root = cache_dir()
     path = root / f"{digest}.json"
     if not path.exists():
@@ -414,8 +415,11 @@ def apply_simplepush_fixes():
         pass
 
 
-def capture_request(url, body, title, notify_type, body_format=None):
-    cached, cache_path = load_cache(url, body, title, notify_type, body_format)
+def capture_request(url, body, title, notify_type, body_format=None, attachments=None):
+    attachments = attachments or []
+    cached, cache_path = load_cache(
+        url, body, title, notify_type, body_format, attachments
+    )
     if cached is not None:
         return cached
 
@@ -657,6 +661,7 @@ def capture_request(url, body, title, notify_type, body_format=None):
             body=body,
             title=title,
             notify_type=notify_type,
+            attach=attachments or None,
         )
     finally:
         requests.sessions.Session.request = original_request
@@ -673,6 +678,7 @@ def main():
     parser.add_argument("--title", default="")
     parser.add_argument("--type", default="info")
     parser.add_argument("--body-format", default="")
+    parser.add_argument("--attach", action="append", default=[])
     args = parser.parse_args()
 
     notify_type = NotifyType.INFO
@@ -684,7 +690,14 @@ def main():
         notify_type = NotifyType.FAILURE
 
     body_format = args.body_format.strip().lower() or None
-    payload = capture_request(args.url, args.body, args.title, notify_type, body_format)
+    payload = capture_request(
+        args.url,
+        args.body,
+        args.title,
+        notify_type,
+        body_format,
+        args.attach,
+    )
     print(json.dumps(payload))
 
 

--- a/internal/testutil/scripts/capture_request.py
+++ b/internal/testutil/scripts/capture_request.py
@@ -94,7 +94,7 @@ DROP_HEADERS = {"x-apprise-id", "x-apprise-recursion-count"}
 KEEP_HEADERS = {"content-type", "accept", "accepts", "authorization"}
 
 BLUESKY_CREATED_AT = "2024-01-01T00:00:00Z"
-CACHE_VERSION = 11
+CACHE_VERSION = 12
 CACHE_ENV = "APPRISE_CAPTURE_CACHE"
 CACHE_DIR_ENV = "APPRISE_CAPTURE_CACHE_DIR"
 CACHE_SUBDIR = ".tmp/pycapture"
@@ -163,6 +163,36 @@ def apprise_git_sha():
     return output.decode("utf-8", "replace").strip()
 
 
+def stable_attachment_cache_entries(attachments):
+    entries = []
+    for attachment in attachments or []:
+        parsed = urlparse(attachment)
+        if parsed.scheme in ("http", "https"):
+            entries.append({"kind": "url", "value": attachment})
+            continue
+
+        path = Path(parsed.path) if parsed.scheme == "file" else Path(attachment)
+        if path.is_file():
+            try:
+                data = path.read_bytes()
+            except OSError:
+                entries.append({"kind": "path", "name": path.name})
+                continue
+            entries.append(
+                {
+                    "kind": "file",
+                    "name": path.name,
+                    "size": len(data),
+                    "sha256": hashlib.sha256(data).hexdigest(),
+                    "query": parsed.query,
+                }
+            )
+            continue
+
+        entries.append({"kind": "path", "name": path.name or attachment})
+    return entries
+
+
 def cache_key(url, body, title, notify_type, body_format, attachments):
     notify_name = notify_type.name if hasattr(notify_type, "name") else str(notify_type)
     try:
@@ -178,7 +208,7 @@ def cache_key(url, body, title, notify_type, body_format, attachments):
         "title": title,
         "notify_type": notify_name,
         "body_format": body_format,
-        "attachments": attachments,
+        "attachments": stable_attachment_cache_entries(attachments),
         "apprise_version": apprise_version,
         "apprise_sha": apprise_git_sha(),
         "python_version": sys.version,
@@ -647,6 +677,8 @@ def capture_request(url, body, title, notify_type, body_format=None, attachments
             response._content = b'{"success":true}'
         else:
             response._content = b"ok"
+        response.headers.setdefault("Content-Type", "text/plain")
+        response.headers["Content-Length"] = str(len(response.content))
         response.url = prepared.url
         return response
 
@@ -659,6 +691,10 @@ def capture_request(url, body, title, notify_type, body_format=None, attachments
         service = apprise.Apprise(asset=asset)
         service.add(url)
         if len(service) == 0:
+            # Some providers can instantiate successfully even when add() leaves
+            # the service list empty in this editable test environment. Fall
+            # back to explicit instantiation so the capture path still exercises
+            # the provider's normal notify flow.
             instance = apprise.Apprise.instantiate(url, asset=asset)
             if instance:
                 service.servers.append(instance)

--- a/internal/testutil/scripts/capture_request.py
+++ b/internal/testutil/scripts/capture_request.py
@@ -94,7 +94,7 @@ DROP_HEADERS = {"x-apprise-id", "x-apprise-recursion-count"}
 KEEP_HEADERS = {"content-type", "accept", "accepts", "authorization"}
 
 BLUESKY_CREATED_AT = "2024-01-01T00:00:00Z"
-CACHE_VERSION = 10
+CACHE_VERSION = 11
 CACHE_ENV = "APPRISE_CAPTURE_CACHE"
 CACHE_DIR_ENV = "APPRISE_CAPTURE_CACHE_DIR"
 CACHE_SUBDIR = ".tmp/pycapture"
@@ -446,6 +446,7 @@ def capture_request(url, body, title, notify_type, body_format=None, attachments
             data=kwargs.get("data"),
             params=kwargs.get("params"),
             json=kwargs.get("json"),
+            files=kwargs.get("files"),
             auth=kwargs.get("auth"),
         )
         prepared = self.prepare_request(req)
@@ -657,6 +658,10 @@ def capture_request(url, body, title, notify_type, body_format=None, attachments
         asset = AppriseAsset(**asset_kwargs)
         service = apprise.Apprise(asset=asset)
         service.add(url)
+        if len(service) == 0:
+            instance = apprise.Apprise.instantiate(url, asset=asset)
+            if instance:
+                service.servers.append(instance)
         success = service.notify(
             body=body,
             title=title,

--- a/internal/testutil/scripts/capture_smtp.py
+++ b/internal/testutil/scripts/capture_smtp.py
@@ -13,6 +13,7 @@ def main():
     parser.add_argument("--body", default="")
     parser.add_argument("--title", default="")
     parser.add_argument("--body-format", default="")
+    parser.add_argument("--attach", action="append", default=[])
     args = parser.parse_args()
 
     asset_kwargs = {}
@@ -22,7 +23,11 @@ def main():
 
     apobj = apprise.Apprise(asset=AppriseAsset(**asset_kwargs))
     apobj.add(args.url)
-    success = apobj.notify(body=args.body, title=args.title)
+    success = apobj.notify(
+        body=args.body,
+        title=args.title,
+        attach=args.attach or None,
+    )
     print(json.dumps({"success": bool(success)}, ensure_ascii=True))
 
 

--- a/internal/testutil/smtp_compare.go
+++ b/internal/testutil/smtp_compare.go
@@ -201,6 +201,15 @@ func decodeSMTPPartBody(t *testing.T, header mail.Header, body io.Reader) string
 	if err != nil {
 		t.Fatalf("read smtp part body failed: %v", err)
 	}
+
+	contentType := header.Get("Content-Type")
+	mediaType, params, err := mime.ParseMediaType(contentType)
+	if err == nil && strings.HasPrefix(strings.ToLower(mediaType), "multipart/") {
+		if boundary := params["boundary"]; boundary != "" {
+			return decodeMultipartBody(t, boundary, raw)
+		}
+	}
+
 	raw = decodeSMTPTransfer(t, header, raw)
 
 	out := string(raw)

--- a/scripts/ci/run_parity_tests.sh
+++ b/scripts/ci/run_parity_tests.sh
@@ -13,3 +13,5 @@ fi
 go run ./internal/tools/parity_report \
   -out reports/parity_report.md \
   -json reports/parity_report.json
+
+go test ./internal/notify -run TestAttachmentRequestParity -count=1 -v


### PR DESCRIPTION
## Summary

- Adds attachment parsing for local files, file:// URLs, and HTTP(S) attachment URLs.
- Wires attachments through the public API (`WithAttachments`), CLI `-a/--attach`, and the notify target dispatch path.
- Implements Python Apprise-compatible attachment handling for JSON, XML, form, Apprise API relay, mailto, and ntfy targets.
- Extends Python parity capture helpers and request/SMTP normalizers so attachment request bodies are compared against upstream Apprise behavior.

## Why

The CLI accepted `--attach` but discarded it before sending, and the runtime had no attachment-aware target interface. Normal Python Apprise supports `--attach` and API-level `attach=...`, so this closes that gap for the generic/custom targets plus common mailto and ntfy paths.

## Validation

- `go test ./... -count=1`

## Coverage notes

The new tests exercise local attachments, multiple attachments, HTTP(S) attachment URLs, CLI and public API usage, JSON/XML base64 payloads, multipart form uploads, Apprise API relay JSON/form modes, SMTP/mailto MIME attachments, and ntfy upload requests against Python Apprise parity baselines.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added message attachment support across notifications (JSON, form multipart, XML, mailto multipart/mixed, and ntfy).
  * Added CLI `--attach`/`-a` to forward attachments into delivery.
  * Added JSON/XML request payload and multipart/mixed message generation for attachments.
* **Bug Fixes**
  * Invalid attachments now fail fast (including oversize responses) instead of being ignored.
  * Attachment parity now includes multipart form-data comparison with normalized part headers.
* **Tests**
  * Added unit and parity tests to validate Go and Python attachment behavior matches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->