### PR TITLE
fix(matrix): generate a unique transaction ID for access-token sends

### DIFF
--- a/internal/notify/matrix.go
+++ b/internal/notify/matrix.go
@@ -13,14 +13,13 @@ import (
 )
 
 const (
-	matrixWebhookPath        = "/api/v1/matrix/hook"
-	matrixV2APIPath          = "/_matrix/client/r0"
-	matrixV3APIPath          = "/_matrix/client/v3"
-	matrixV2MediaPath        = "/_matrix/media/r0"
-	matrixV3MediaPath        = "/_matrix/media/v3"
-	matrixT2BotWebhookURL    = "https://webhooks.t2bot.io/api/v1/matrix/hook/"
-	matrixDefaultUserAgent   = "Apprise"
-	matrixFixedTransactionID = "00000000-0000-4000-8000-000000000000"
+	matrixWebhookPath      = "/api/v1/matrix/hook"
+	matrixV2APIPath        = "/_matrix/client/r0"
+	matrixV3APIPath        = "/_matrix/client/v3"
+	matrixV2MediaPath      = "/_matrix/media/r0"
+	matrixV3MediaPath      = "/_matrix/media/v3"
+	matrixT2BotWebhookURL  = "https://webhooks.t2bot.io/api/v1/matrix/hook/"
+	matrixDefaultUserAgent = "Apprise"
 )
 
 const (
@@ -231,7 +230,7 @@ func (m *MatrixTarget) SendWithAttachments(body, title string, notifyType Notify
 func (m *MatrixTarget) sendServer(body, title string, notifyType NotifyType, attachments []Attachment) error {
 	if m.accessToken == "" && m.password != "" && m.user == "" {
 		m.accessToken = m.password
-		m.transactionIDString = matrixFixedTransactionID
+		m.transactionIDString = newUUIDv4()
 	}
 
 	if m.accessToken == "" {

--- a/internal/notify/matrix_transaction_test.go
+++ b/internal/notify/matrix_transaction_test.go
@@ -1,0 +1,52 @@
+package notify_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/unraid/apprise-go/internal/notify"
+	"github.com/unraid/apprise-go/internal/testutil"
+)
+
+// TestMatrixAccessTokenTransactionIDIsUnique guards the Matrix
+// /send/m.room.message transaction id on the bare access-token path.
+//
+// That endpoint is idempotent and keyed on the transaction id: a homeserver
+// that has already seen an id replies 200 with the original event and creates
+// nothing new. So reusing one id makes every send after the first vanish
+// without an error anywhere — the notification simply never arrives.
+func TestMatrixAccessTokenTransactionIDIsUnique(t *testing.T) {
+	t.Setenv("APPRISE_FIXED_TIME", "")
+	notify.ConfigureStorage("", 8, nil)
+	t.Cleanup(func() { notify.ConfigureStorage("", 8, nil) })
+
+	const url = "matrixs://tokenabc123@matrix.example.com/%23room:example.com?e2ee=no"
+
+	send := func() string {
+		t.Helper()
+		specs := testutil.CaptureGoRequests(t, func() error {
+			return notify.SendTargetURL(url, "body", "title", "", notify.NotifyInfo)
+		})
+		for _, spec := range specs {
+			if idx := strings.Index(spec.URL, "/send/m.room.message/"); idx >= 0 {
+				return spec.URL[idx+len("/send/m.room.message/"):]
+			}
+		}
+		t.Fatal("no m.room.message send was issued")
+		return ""
+	}
+
+	first := send()
+	second := send()
+
+	if first == "" || second == "" {
+		t.Fatal("transaction id missing from send path")
+	}
+	if first == second {
+		t.Fatalf("transaction id reused across sends (%q); the homeserver will "+
+			"treat the second send as a retransmission and drop it", first)
+	}
+	if first == "00000000-0000-4000-8000-000000000000" {
+		t.Fatalf("transaction id is the deterministic placeholder %q rather than a generated value", first)
+	}
+}


### PR DESCRIPTION
Fixes #86.

### Problem

On the bare access-token path (`matrix://{token}@{host}/!{room}`), `sendServer()` set the message transaction ID to a hardcoded constant. Since Matrix's `/send/m.room.message/{txnId}` endpoint deduplicates on that ID, the homeserver silently discarded every message after the first while still answering 200 — so notifications vanished with no error anywhere. Details and Synapse logs in the issue.

### Change

Replaces the constant with the existing `newUUIDv4()` helper (already in the same package, `internal/notify/home_assistant.go`), and drops the now-unused `matrixFixedTransactionID`.

```diff
-		m.transactionIDString = matrixFixedTransactionID
+		m.transactionIDString = newUUIDv4()
```

This matches upstream Python apprise, which does `self.transaction_id = uuid.uuid4()` at the same point: [`apprise/plugins/matrix/base.py#L837-L839`](https://github.com/caronc/apprise/blob/v1.12.0/apprise/plugins/matrix/base.py#L837-L839) (v1.12.0).

### Parity / determinism

`newUUIDv4()` still returns the fixed all-zero UUID when `APPRISE_FIXED_TIME` is set, so parity fixtures and golden files stay deterministic. No golden files needed regeneration — `internal/parity/providers/matrix/golden.json` covers the login path, which uses the integer counter and is untouched.

### Test

Adds `TestMatrixAccessTokenTransactionIDIsUnique`, which performs two token-auth sends and asserts the transaction IDs in the request paths differ. Verified it fails on `main` with the exact production symptom and passes with the fix. Full `go test ./...` is green.

### Note

This is one possible fix — deliberately minimal and matching upstream. If you'd prefer a different approach (e.g. also addressing `advanceMessageTransaction()`'s `m.accessToken != m.password` guard, which can never be true on this path since `accessToken` is assigned from `password` a line earlier), feel free to take it in that direction instead. Happy to adjust.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matrix notifications by using unique transaction identifiers for access-token authentication.
  * Prevented consecutive notifications from reusing a placeholder or duplicate transaction ID.

* **Tests**
  * Added regression coverage to verify transaction IDs are present and unique across consecutive sends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->