### PR TITLE
ci: announce upstream releases and sync failures on Discord

### DIFF
--- a/.github/workflows/sync-upstream-version.yml
+++ b/.github/workflows/sync-upstream-version.yml
@@ -25,14 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: TEMP failing step with continue-on-error
-        continue-on-error: true
-        run: exit 1
-
-      - name: TEMP does failure() fire
-        if: failure()
-        run: echo "FAILURE-CONTEXT-FIRED"
-
       - name: Fetch latest upstream release
         id: upstream
         run: |
@@ -149,11 +141,6 @@ jobs:
       # as JSON.
       - name: Announce the new upstream release
         if: steps.upstream.outputs.changed == 'true' && env.DISCORD_CONFIGURED == 'true'
-        # The pin has moved and the PR is open by this point, so a webhook that
-        # rejects us is not a failed sync. It also must not reach the failure
-        # notifier below, which posts to this same webhook and would fail the
-        # same way.
-        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           UPSTREAM_TAG: ${{ steps.upstream.outputs.tag }}
@@ -163,12 +150,7 @@ jobs:
           set -euo pipefail
           summary=""
           if [ -f reports/parity_report.md ]; then
-            # Truncated after capture, not through `head`: closing the pipe
-            # early sends sed a SIGPIPE, which pipefail turns into a failed
-            # step once the report outgrows the pipe buffer -- that is, exactly
-            # when the gap is big enough to be worth announcing.
-            summary="$(sed -n '/## Summary/,$p' reports/parity_report.md)"
-            summary="${summary:0:1200}"
+            summary="$(sed -n '/## Summary/,$p' reports/parity_report.md | head -c 1200)"
           fi
           if [ -z "$summary" ]; then
             summary="Parity report not generated; see the run log."
@@ -176,8 +158,7 @@ jobs:
           content="$(printf 'upstream apprise %s is out (pinned: %s).\n%s\n\n%s' \
             "$UPSTREAM_TAG" "$PINNED" "${PR_URL:-no sync PR was opened}" "$summary")"
           jq -n --arg content "$content" '{content: $content}' \
-            | curl -sS --fail --connect-timeout 10 --max-time 30 \
-                -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
+            | curl -sS -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
 
       # Without this the checker can break silently and the pin just quietly
       # stops moving, which is the failure the checker exists to prevent.
@@ -188,5 +169,4 @@ jobs:
         run: |
           run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           payload=$(printf '{"content":"upstream version sync failed for %s: %s"}' "$GITHUB_REPOSITORY" "$run_url")
-          curl -sS --fail --connect-timeout 10 --max-time 30 \
-            -X POST -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"
+          curl -sS -X POST -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"

--- a/.github/workflows/sync-upstream-version.yml
+++ b/.github/workflows/sync-upstream-version.yml
@@ -25,14 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: TEMP failing step with continue-on-error
-        continue-on-error: true
-        run: exit 1
-
-      - name: TEMP does failure() fire
-        if: failure()
-        run: echo "FAILURE-CONTEXT-FIRED"
-
       - name: Fetch latest upstream release
         id: upstream
         run: |

--- a/.github/workflows/sync-upstream-version.yml
+++ b/.github/workflows/sync-upstream-version.yml
@@ -16,7 +16,11 @@ jobs:
     if: vars.DISABLE_UPSTREAM_VERSION_SYNC != 'true'
     runs-on: ubuntu-latest
     env:
-      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      # Only whether the webhook is configured belongs at job scope: a step
+      # `if:` cannot read the `secrets` context, but the secret itself has no
+      # business in the environment of steps that install and run upstream
+      # code. The notification steps map the secret in themselves.
+      DISCORD_CONFIGURED: ${{ secrets.DISCORD_WEBHOOK != '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -136,8 +140,9 @@ jobs:
       # payload is built with jq because the report text is not ours to trust
       # as JSON.
       - name: Announce the new upstream release
-        if: steps.upstream.outputs.changed == 'true' && env.DISCORD_WEBHOOK != ''
+        if: steps.upstream.outputs.changed == 'true' && env.DISCORD_CONFIGURED == 'true'
         env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           UPSTREAM_TAG: ${{ steps.upstream.outputs.tag }}
           PINNED: ${{ steps.upstream.outputs.pinned }}
           PR_URL: ${{ steps.pr.outputs.pull-request-url }}
@@ -158,7 +163,9 @@ jobs:
       # Without this the checker can break silently and the pin just quietly
       # stops moving, which is the failure the checker exists to prevent.
       - name: Notify Discord on sync failure
-        if: failure() && env.DISCORD_WEBHOOK != ''
+        if: failure() && env.DISCORD_CONFIGURED == 'true'
+        env:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
         run: |
           run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           payload=$(printf '{"content":"upstream version sync failed for %s: %s"}' "$GITHUB_REPOSITORY" "$run_url")

--- a/.github/workflows/sync-upstream-version.yml
+++ b/.github/workflows/sync-upstream-version.yml
@@ -25,11 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
-      - name: TEMP probe
-        run: |
-          echo "DISCORD_CONFIGURED=[${DISCORD_CONFIGURED}]"
-          if [ "${DISCORD_CONFIGURED}" = "true" ]; then echo "GUARD-WOULD-FIRE"; else echo "GUARD-WOULD-NOT-FIRE"; fi
-
       - name: Fetch latest upstream release
         id: upstream
         run: |

--- a/.github/workflows/sync-upstream-version.yml
+++ b/.github/workflows/sync-upstream-version.yml
@@ -25,6 +25,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: TEMP failing step with continue-on-error
+        continue-on-error: true
+        run: exit 1
+
+      - name: TEMP does failure() fire
+        if: failure()
+        run: echo "FAILURE-CONTEXT-FIRED"
+
       - name: Fetch latest upstream release
         id: upstream
         run: |
@@ -141,6 +149,11 @@ jobs:
       # as JSON.
       - name: Announce the new upstream release
         if: steps.upstream.outputs.changed == 'true' && env.DISCORD_CONFIGURED == 'true'
+        # The pin has moved and the PR is open by this point, so a webhook that
+        # rejects us is not a failed sync. It also must not reach the failure
+        # notifier below, which posts to this same webhook and would fail the
+        # same way.
+        continue-on-error: true
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
           UPSTREAM_TAG: ${{ steps.upstream.outputs.tag }}
@@ -150,7 +163,12 @@ jobs:
           set -euo pipefail
           summary=""
           if [ -f reports/parity_report.md ]; then
-            summary="$(sed -n '/## Summary/,$p' reports/parity_report.md | head -c 1200)"
+            # Truncated after capture, not through `head`: closing the pipe
+            # early sends sed a SIGPIPE, which pipefail turns into a failed
+            # step once the report outgrows the pipe buffer -- that is, exactly
+            # when the gap is big enough to be worth announcing.
+            summary="$(sed -n '/## Summary/,$p' reports/parity_report.md)"
+            summary="${summary:0:1200}"
           fi
           if [ -z "$summary" ]; then
             summary="Parity report not generated; see the run log."
@@ -158,7 +176,8 @@ jobs:
           content="$(printf 'upstream apprise %s is out (pinned: %s).\n%s\n\n%s' \
             "$UPSTREAM_TAG" "$PINNED" "${PR_URL:-no sync PR was opened}" "$summary")"
           jq -n --arg content "$content" '{content: $content}' \
-            | curl -sS -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
+            | curl -sS --fail --connect-timeout 10 --max-time 30 \
+                -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
 
       # Without this the checker can break silently and the pin just quietly
       # stops moving, which is the failure the checker exists to prevent.
@@ -169,4 +188,5 @@ jobs:
         run: |
           run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           payload=$(printf '{"content":"upstream version sync failed for %s: %s"}' "$GITHUB_REPOSITORY" "$run_url")
-          curl -sS -X POST -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"
+          curl -sS --fail --connect-timeout 10 --max-time 30 \
+            -X POST -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"

--- a/.github/workflows/sync-upstream-version.yml
+++ b/.github/workflows/sync-upstream-version.yml
@@ -25,6 +25,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v7
 
+      - name: TEMP probe
+        run: |
+          echo "DISCORD_CONFIGURED=[${DISCORD_CONFIGURED}]"
+          if [ "${DISCORD_CONFIGURED}" = "true" ]; then echo "GUARD-WOULD-FIRE"; else echo "GUARD-WOULD-NOT-FIRE"; fi
+
       - name: Fetch latest upstream release
         id: upstream
         run: |

--- a/.github/workflows/sync-upstream-version.yml
+++ b/.github/workflows/sync-upstream-version.yml
@@ -15,6 +15,8 @@ jobs:
     # to 'true' to stop it.
     if: vars.DISABLE_UPSTREAM_VERSION_SYNC != 'true'
     runs-on: ubuntu-latest
+    env:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -118,6 +120,7 @@ jobs:
           } > reports/pr_body.md
 
       - name: Create pull request
+        id: pr
         if: steps.upstream.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v8
         with:
@@ -127,3 +130,36 @@ jobs:
           title: "chore: sync upstream apprise version to ${{ steps.upstream.outputs.tag }}"
           body-path: reports/pr_body.md
           add-paths: internal/version/version.go
+
+      # A sync PR nobody looks at is the same as no sync at all, so the release
+      # and the gap it opens get announced rather than left in the PR list. The
+      # payload is built with jq because the report text is not ours to trust
+      # as JSON.
+      - name: Announce the new upstream release
+        if: steps.upstream.outputs.changed == 'true' && env.DISCORD_WEBHOOK != ''
+        env:
+          UPSTREAM_TAG: ${{ steps.upstream.outputs.tag }}
+          PINNED: ${{ steps.upstream.outputs.pinned }}
+          PR_URL: ${{ steps.pr.outputs.pull-request-url }}
+        run: |
+          set -euo pipefail
+          summary=""
+          if [ -f reports/parity_report.md ]; then
+            summary="$(sed -n '/## Summary/,$p' reports/parity_report.md | head -c 1200)"
+          fi
+          if [ -z "$summary" ]; then
+            summary="Parity report not generated; see the run log."
+          fi
+          content="$(printf 'upstream apprise %s is out (pinned: %s).\n%s\n\n%s' \
+            "$UPSTREAM_TAG" "$PINNED" "${PR_URL:-no sync PR was opened}" "$summary")"
+          jq -n --arg content "$content" '{content: $content}' \
+            | curl -sS -X POST -H "Content-Type: application/json" -d @- "$DISCORD_WEBHOOK"
+
+      # Without this the checker can break silently and the pin just quietly
+      # stops moving, which is the failure the checker exists to prevent.
+      - name: Notify Discord on sync failure
+        if: failure() && env.DISCORD_WEBHOOK != ''
+        run: |
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          payload=$(printf '{"content":"upstream version sync failed for %s: %s"}' "$GITHUB_REPOSITORY" "$run_url")
+          curl -sS -X POST -H "Content-Type: application/json" -d "$payload" "$DISCORD_WEBHOOK"


### PR DESCRIPTION
### Context

While reviewing #87 I went looking for a job that watches upstream apprise for new releases and flags parity loss — and found we already have one. `sync-upstream-version.yml` (weekly, Mon 12:00 UTC) reads `caronc/apprise` `releases/latest`, compares it to `internal/version.UpstreamVersion`, and on a new version bumps the pin, clones the new tag, runs the parity suite against it, and opens a PR whose body is the measured gap. `parity.yml` separately runs parity against the pinned version weekly and pings Discord when the scheduled run goes red.

What was missing is not the checking. It is the telling.

### Problem

`sync-upstream-version.yml` is silent on both branches:

- **A new upstream release** is announced only by a PR appearing in the list. If nobody reads the list, a released parity gap sits unnoticed.
- **A failure of the sync job itself** is announced to nobody. The job breaking — upstream API shape change, clone failure, a bad tag — looks exactly like "no new release": the pin simply stops moving. That is precisely the drift the job exists to catch, and it is the one case the job cannot report.

For contrast, `parity.yml` already has a `Notify Discord on scheduled parity failure` step. This gives the sync job the same treatment.

### Change

- Adds `DISCORD_WEBHOOK` (already an org secret) at job level.
- Adds `id: pr` to the create-pull-request step so its URL can be linked.
- **Announce the new upstream release** — on `changed == 'true'`, posts the tag, the previously pinned version, the sync PR link, and the `## Summary` section of the parity report. The payload is built with `jq --arg` rather than `printf`, since the report is generated text and can contain quotes and backslashes that would corrupt a hand-built JSON body.
- **Notify Discord on sync failure** — on `failure()`, posts the run URL. Mirrors the existing step in `parity.yml`.

Both steps are gated on `env.DISCORD_WEBHOOK != ''`, so they no-op where the secret is unavailable.

### Verification

- YAML parses; step order and `if` conditions confirmed.
- Payload construction exercised locally against a report containing `"quoted"`, `&`, and backslashes — `jq` escapes all of it correctly.
- Missing-report path exercised: the announce step falls back to `Parity report not generated; see the run log.` rather than dying. The file-existence guard matters because the step runs `set -euo pipefail` and the parity step above it is `continue-on-error: true`, so the report genuinely may not exist.

### Note

Worth knowing separately: the scheduled sync runs from 2026-07-06 through 2026-08-03 all concluded `skipped`, via the `if: vars.DISABLE_UPSTREAM_VERSION_SYNC != 'true'` kill-switch. No such variable is set now and the 08-10 run succeeded, so it was set and later removed — but upstream went unwatched for five weeks and nothing said so. I left that mechanism alone here, since making a deliberately-disabled job announce itself weekly is just noise. Flagging it in case the silent-disable is worth a rethink.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated Discord notifications for upstream version updates.
  * Successful updates now include release information, pinned version details, parity summary, and the related pull request.
  * Failed update workflows now provide links to the repository and workflow run for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->