### PR TITLE
fix(matrix): advance the transaction ID between events within a notification

### DIFF
--- a/internal/notify/matrix.go
+++ b/internal/notify/matrix.go
@@ -409,9 +409,25 @@ func (m *MatrixTarget) uploadFetch(attachment Attachment, params url.Values) (bo
 
 // advanceMessageTransaction moves to the next transaction id, which upstream
 // does after every event so a retry is not mistaken for a retransmission.
+//
+// A notification can produce several events in one room -- a file per
+// attachment, then the text -- and an id that does not move between them is
+// what the homeserver uses to recognize a retransmission, so everything after
+// the first event is dropped. The spec asks for an id unique across requests
+// sharing an access token, so this advances per event rather than per room.
 func (m *MatrixTarget) advanceMessageTransaction() {
-	if m.version == matrixVersionV3 && m.accessToken != "" &&
-		m.accessToken != m.password && m.transactionIDString == "" {
+	if m.version != matrixVersionV3 || m.accessToken == "" {
+		return
+	}
+
+	// The token path carries its id as a uuid string rather than a counter,
+	// so it advances by generating the next one.
+	if m.transactionIDString != "" {
+		m.transactionIDString = newUUIDv4()
+		return
+	}
+
+	if m.accessToken != m.password {
 		m.transactionID++
 	}
 }
@@ -727,8 +743,8 @@ func (m *MatrixTarget) sendMessage(roomID, body, title string, notifyType Notify
 
 	path := m.messagePath(roomID)
 	ok, _, _ := m.fetch(path, payload, nil, m.messageMethod(), "")
-	if ok && m.version == matrixVersionV3 && m.accessToken != "" && m.accessToken != m.password && m.transactionIDString == "" {
-		m.transactionID++
+	if ok {
+		m.advanceMessageTransaction()
 	}
 	_ = notifyType
 	return ok

--- a/internal/notify/matrix_e2ee.go
+++ b/internal/notify/matrix_e2ee.go
@@ -641,7 +641,10 @@ func (m *MatrixTarget) transactionValue() string {
 // advanceTransaction moves the counter on, keeping it in storage so a later
 // process does not reuse an id the server has already seen.
 func (m *MatrixTarget) advanceTransaction() {
+	// The token path carries its id as a uuid string; there is no counter to
+	// persist, so it advances by generating the next one.
 	if m.transactionIDString != "" {
+		m.transactionIDString = newUUIDv4()
 		return
 	}
 

--- a/internal/notify/matrix_transaction_test.go
+++ b/internal/notify/matrix_transaction_test.go
@@ -50,3 +50,91 @@ func TestMatrixAccessTokenTransactionIDIsUnique(t *testing.T) {
 		t.Fatalf("transaction id is the deterministic placeholder %q rather than a generated value", first)
 	}
 }
+
+// sendTransactionIDs returns the transaction id of every m.room.message send
+// issued by one notification, in order.
+func sendTransactionIDs(t *testing.T, specs []notify.RequestSpec) []string {
+	t.Helper()
+
+	const marker = "/send/m.room.message/"
+	ids := []string{}
+	for _, spec := range specs {
+		if idx := strings.Index(spec.URL, marker); idx >= 0 {
+			ids = append(ids, spec.URL[idx+len(marker):])
+		}
+	}
+	return ids
+}
+
+// assertUniqueTransactionIDs fails when a notification reuses an id, naming
+// the collision rather than only reporting that one happened.
+func assertUniqueTransactionIDs(t *testing.T, ids []string, want int) {
+	t.Helper()
+
+	if len(ids) != want {
+		t.Fatalf("expected %d m.room.message sends, got %d", want, len(ids))
+	}
+
+	seen := map[string]int{}
+	for i, id := range ids {
+		if first, ok := seen[id]; ok {
+			t.Fatalf("sends %d and %d share transaction id %q; a homeserver is "+
+				"entitled to treat the later one as a retransmission and drop it",
+				first, i, id)
+		}
+		seen[id] = i
+	}
+}
+
+// TestMatrixMultiRoomTransactionIDsAreUnique covers a notification addressed
+// to more than one room.
+//
+// Synapse tolerates a repeat here, because it keys idempotency on the request
+// path and that carries the room id. The spec is the stricter of the two --
+// it asks for an id unique across requests sharing an access token -- so this
+// pins the behavior a homeserver keying on the token alone would need.
+func TestMatrixMultiRoomTransactionIDsAreUnique(t *testing.T) {
+	t.Setenv("APPRISE_FIXED_TIME", "")
+	notify.ConfigureStorage("", 8, nil)
+	t.Cleanup(func() { notify.ConfigureStorage("", 8, nil) })
+
+	specs := testutil.CaptureGoRequests(t, func() error {
+		return notify.SendTargetURL(
+			"matrixs://tokenabc123@matrix.example.com/%23room1:example.com/%23room2:example.com?e2ee=no",
+			"body", "title", "", notify.NotifyInfo)
+	})
+
+	assertUniqueTransactionIDs(t, sendTransactionIDs(t, specs), 2)
+}
+
+// TestMatrixAttachmentTransactionIDsAreUnique covers the several events a
+// single room receives when files are attached: one per file, then the text.
+//
+// This is the case that fails against a real homeserver: same room, so same
+// request path, so a repeated id is a retransmission. It costs the message
+// body itself, since the text is sent last and is what gets discarded.
+func TestMatrixAttachmentTransactionIDsAreUnique(t *testing.T) {
+	t.Setenv("APPRISE_FIXED_TIME", "")
+	notify.ConfigureStorage("", 8, nil)
+	t.Cleanup(func() { notify.ConfigureStorage("", 8, nil) })
+
+	specs := testutil.CaptureGoRequests(t, func() error {
+		target, err := notify.ParseURL("matrixs://tokenabc123@matrix.example.com/%23room1:example.com?e2ee=no")
+		if err != nil {
+			return err
+		}
+		sender, err := notify.NewTarget(target)
+		if err != nil {
+			return err
+		}
+
+		return notify.DispatchSend(sender, "body", "title", notify.NotifyInfo,
+			[]notify.Attachment{
+				{Name: "one.txt", MIMEType: "text/plain", Data: []byte("first")},
+				{Name: "two.txt", MIMEType: "text/plain", Data: []byte("second")},
+			})
+	})
+
+	// Two attachment events plus the text message.
+	assertUniqueTransactionIDs(t, sendTransactionIDs(t, specs), 3)
+}

--- a/internal/parity/providers/matrix/cases.json
+++ b/internal/parity/providers/matrix/cases.json
@@ -42,5 +42,12 @@
       "%7Brepo%7D/internal/parity/fixtures/pixel.png",
       "%7Brepo%7D/internal/parity/fixtures/notes.txt"
     ]
+  },
+  {
+    "name": "multi-room",
+    "url": "matrixs://user:pass@matrix.example.com/%23room1:example.com/%23room2:example.com?e2ee=no",
+    "body": "body",
+    "title": "t",
+    "type": "info"
   }
 ]

--- a/internal/parity/providers/matrix/golden.json
+++ b/internal/parity/providers/matrix/golden.json
@@ -217,5 +217,84 @@
         "url": "https://matrix.example.com/_matrix/client/v3/rooms/%21room%3Amatrix.example.com/send/m.room.message/2"
       }
     ]
+  },
+  {
+    "name": "multi-room",
+    "requests": [
+      {
+        "body": "null",
+        "headers": {
+          "accept": "application/json",
+          "content-type": "application/json",
+          "user-agent": "Apprise"
+        },
+        "method": "GET",
+        "url": "https://matrix.example.com/.well-known/matrix/client"
+      },
+      {
+        "body": "null",
+        "headers": {
+          "accept": "application/json",
+          "content-type": "application/json",
+          "user-agent": "Apprise"
+        },
+        "method": "GET",
+        "url": "https://matrix.example.com/_matrix/client/versions"
+      },
+      {
+        "body": "{\"type\": \"m.login.password\", \"identifier\": {\"type\": \"m.id.user\", \"user\": \"user\"}, \"password\": \"pass\", \"initial_device_display_name\": \"Apprise\"}",
+        "headers": {
+          "accept": "application/json",
+          "content-type": "application/json",
+          "user-agent": "Apprise"
+        },
+        "method": "POST",
+        "url": "https://matrix.example.com/_matrix/client/v3/login"
+      },
+      {
+        "body": "{}",
+        "headers": {
+          "accept": "application/json",
+          "authorization": "Bearer token",
+          "content-type": "application/json",
+          "user-agent": "Apprise"
+        },
+        "method": "POST",
+        "url": "https://matrix.example.com/_matrix/client/v3/join/%23room1%3Aexample.com"
+      },
+      {
+        "body": "{\"msgtype\": \"m.text\", \"body\": \"# t\\r\\nbody\"}",
+        "headers": {
+          "accept": "application/json",
+          "authorization": "Bearer token",
+          "content-type": "application/json",
+          "user-agent": "Apprise"
+        },
+        "method": "PUT",
+        "url": "https://matrix.example.com/_matrix/client/v3/rooms/%21room%3Amatrix.example.com/send/m.room.message/0"
+      },
+      {
+        "body": "{}",
+        "headers": {
+          "accept": "application/json",
+          "authorization": "Bearer token",
+          "content-type": "application/json",
+          "user-agent": "Apprise"
+        },
+        "method": "POST",
+        "url": "https://matrix.example.com/_matrix/client/v3/join/%23room2%3Aexample.com"
+      },
+      {
+        "body": "{\"msgtype\": \"m.text\", \"body\": \"# t\\r\\nbody\"}",
+        "headers": {
+          "accept": "application/json",
+          "authorization": "Bearer token",
+          "content-type": "application/json",
+          "user-agent": "Apprise"
+        },
+        "method": "PUT",
+        "url": "https://matrix.example.com/_matrix/client/v3/rooms/%21room%3Amatrix.example.com/send/m.room.message/1"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
Fixes #88.

### Problem

#87 gave each `sendServer()` call a fresh UUID, fixing the case *between* notifications. Within a single notification the id still never advances, because both advance sites gate on `transactionIDString == ""` — always false on the token path:

- `advanceMessageTransaction()` (`internal/notify/matrix.go`)
- the inline bump in `sendMessage()` (`internal/notify/matrix.go`)

So every event a notification emits reuses one id.

### Correction to the issue

The issue reasons that transaction ids are scoped per access token and not per room. That is what the spec asks of clients, but it is not how Synapse enforces idempotency, and the difference changes which half of this is user-visible.

Synapse keys the transaction cache on a tuple of the **request path, user ID and device ID** ([`rest/client/transactions.py#L78-L92`](https://github.com/element-hq/synapse/blob/v1.158.0/synapse/rest/client/transactions.py#L78-L92)), and the persistence-layer check is keyed `{room_id, user_id, device_id, txn_id}` ([`storage/databases/main/events_worker.py#L2282-L2299`](https://github.com/element-hq/synapse/blob/v1.158.0/synapse/storage/databases/main/events_worker.py#L2282-L2299)). Both carry the room — the first via the path — so:

- **Multiple rooms** — different paths, so Synapse does **not** deduplicate. Confirmed against a live server on the current release: both rooms receive the message. The multi-room reproduction in the issue does not fail on Synapse.
- **Attachments in one room** — same path, so the repeat is treated as a retransmission. Confirmed on the same server: sending two files plus text delivers only the first file. The second file and the message body are dropped, silently, with a 200 each time.

So the reported symptom is real and the fix stands, but the room-to-room case is a spec-compliance concern rather than something Synapse users observe. The spec asks clients to "generate an ID unique across requests with the same access token", so a homeserver keying on the token alone would drop those sends; this change satisfies that too.

### Change

- `advanceMessageTransaction()` advances the string path by generating the next UUID, leaving the counter path as it was.
- `sendMessage()` calls that helper instead of repeating the guard inline; the duplicated condition is what let the two paths drift apart.
- `advanceTransaction()` in `matrix_e2ee.go` short-circuited on the same condition and gets the same treatment.

### Divergence from upstream

Worth flagging: this is a deliberate divergence, not a parity fix.

Upstream Python has the same defect — every advance site is guarded by `if self.access_token != self.password:`, never true on the token path since `access_token` is assigned from `password` a few lines earlier ([`base.py#L837-L839`](https://github.com/caronc/apprise/blob/v1.12.0/apprise/plugins/matrix/base.py#L837-L839)). There the guard is load-bearing: `transaction_id` holds a `uuid.UUID` on that path, and `uuid.uuid4() += 1` raises `TypeError`, so upstream cannot drop it the way this does.

I kept the `accessToken != password` check on the counter path so the structure still maps onto upstream, though it is unreachable on the token path now. Happy to remove it. I can also report this upstream if useful.

### Parity / determinism

No golden regeneration needed. `newUUIDv4()` returns the fixed placeholder under `APPRISE_FIXED_TIME`, so fixtures are unchanged, and the counter path the Matrix goldens exercise behaves exactly as before. `go test ./...` is green.

### Tests

Both added to `matrix_transaction_test.go` and verified to fail on `main`:

- `TestMatrixAttachmentTransactionIDsAreUnique` — one room, two attachments; asserts three sends (two files, then the text) with distinct ids. This is the case that fails against a real homeserver.
- `TestMatrixMultiRoomTransactionIDsAreUnique` — two rooms; pins the stricter spec behaviour that Synapse happens not to require.

The shared helper also pins the expected send count, so a regression that stops emitting events cannot pass by looking unique.

### Verified against a real homeserver

Synapse, token auth. Attachments now produce three distinct events and the body arrives:

```
PUT .../send/m.room.message/12adc283-e343-4dbf-861c-7926a74e60ff
PUT .../send/m.room.message/3c289874-ce3b-4cd1-b562-ed3a44c49678
PUT .../send/m.room.message/82d3aaa7-ab7b-4c44-b3c9-14d2fa67a1b9
```

Before this change the same run delivered only the first file. Also exercised one token across 15+ sends with no dedup.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Matrix notification processing so message and attachment events advance correctly.
  * Ensured each event receives a unique transaction ID, including notifications sent to multiple rooms.
  * Improved reliability for workflows containing multiple attachments followed by a text message.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->