### PR TITLE
feat(notify): add WPUSH notification provider

### DIFF
--- a/internal/notify/overflow.go
+++ b/internal/notify/overflow.go
@@ -578,6 +578,7 @@ var overflowLimitsBySchema = map[string]overflowLimits{
 	"windows":    {bodyMax: 32768, titleMax: 250, lineMax: 2, amalgamateTitle: false, buffer: 0, countThreshold: 130, maxCountWidth: 12, format: "text"},
 	"workflow":   {bodyMax: 1000, titleMax: 250, lineMax: 0, amalgamateTitle: false, buffer: 0, countThreshold: 130, maxCountWidth: 12, format: "markdown"},
 	"workflows":  {bodyMax: 1000, titleMax: 250, lineMax: 0, amalgamateTitle: false, buffer: 0, countThreshold: 130, maxCountWidth: 12, format: "markdown"},
+	"wpush":      {bodyMax: 10000, titleMax: 255, lineMax: 0, amalgamateTitle: false, buffer: 0, countThreshold: 130, maxCountWidth: 12, format: "text"},
 	"wxpusher":   {bodyMax: 32768, titleMax: 250, lineMax: 0, amalgamateTitle: false, buffer: 0, countThreshold: 130, maxCountWidth: 12, format: "text"},
 	"wxteams":    {bodyMax: -1, titleMax: 0, lineMax: 0, amalgamateTitle: false, buffer: 0, countThreshold: 130, maxCountWidth: 12, format: "markdown"},
 	"x":          {bodyMax: -1, titleMax: 0, lineMax: 0, amalgamateTitle: false, buffer: 0, countThreshold: 130, maxCountWidth: 12, format: "text"},

--- a/internal/notify/registry_push.go
+++ b/internal/notify/registry_push.go
@@ -47,6 +47,7 @@ var pushSchemas = map[string]struct{}{
 	"pushed":     {},
 	"pushme":     {},
 	"pushplus":   {},
+	"wpush":      {},
 	"pushward":   {},
 	"wecom":      {},
 	"pushy":      {},

--- a/internal/notify/target.go
+++ b/internal/notify/target.go
@@ -674,6 +674,9 @@ var targetBuilders = map[string]buildTargetFunc{
 	"pushplus": func(parsed *ParsedURL) (Sender, error) {
 		return NewPushplusTarget(parsed)
 	},
+	"wpush": func(parsed *ParsedURL) (Sender, error) {
+		return NewWPushTarget(parsed)
+	},
 	"pushy": func(parsed *ParsedURL) (Sender, error) {
 		return NewPushyTarget(parsed)
 	},

--- a/internal/notify/wpush.go
+++ b/internal/notify/wpush.go
@@ -3,6 +3,8 @@ package notify
 import (
 	"encoding/json"
 	"fmt"
+	"io"
+	"net/http"
 	"regexp"
 	"strings"
 )
@@ -128,12 +130,34 @@ func (w *WPushTarget) Send(body, title string, notifyType NotifyType) error {
 		return err
 	}
 
+	req, err := spec.HTTPRequest()
+	if err != nil {
+		return err
+	}
+
+	resp, err := httpClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	// WPUSH defines success as JSON code === 0. Decode the body first so a
+	// non-2xx response that still carries code:0 is not rejected by the
+	// generic HTTP-status helper.
 	var response struct {
 		Code    int    `json:"code"`
 		Message string `json:"message"`
 	}
-	if err := doJSONRequest(spec, &response); err != nil {
-		return err
+	if err := json.Unmarshal(raw, &response); err != nil {
+		if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+			return &HTTPStatusError{StatusCode: resp.StatusCode}
+		}
+		return fmt.Errorf("wpush invalid json response: %w", err)
 	}
 	if response.Code != 0 {
 		msg := response.Message

--- a/internal/notify/wpush.go
+++ b/internal/notify/wpush.go
@@ -146,11 +146,12 @@ func (w *WPushTarget) Send(body, title string, notifyType NotifyType) error {
 		return err
 	}
 
-	// WPUSH defines success as JSON code === 0. Decode the body first so a
+	// WPUSH defines success as an explicit JSON code === 0. Decode first so a
 	// non-2xx response that still carries code:0 is not rejected by the
-	// generic HTTP-status helper.
+	// generic HTTP-status helper. Code must be a pointer so missing/null
+	// fields are not confused with numeric zero.
 	var response struct {
-		Code    int    `json:"code"`
+		Code    *int   `json:"code"`
 		Message string `json:"message"`
 	}
 	if err := json.Unmarshal(raw, &response); err != nil {
@@ -159,12 +160,15 @@ func (w *WPushTarget) Send(body, title string, notifyType NotifyType) error {
 		}
 		return fmt.Errorf("wpush invalid json response: %w", err)
 	}
-	if response.Code != 0 {
+	if response.Code == nil || *response.Code != 0 {
 		msg := response.Message
 		if msg == "" {
 			msg = "Unknown error"
 		}
-		return fmt.Errorf("wpush api code=%d: %s", response.Code, msg)
+		if response.Code == nil {
+			return fmt.Errorf("wpush api code missing: %s", msg)
+		}
+		return fmt.Errorf("wpush api code=%d: %s", *response.Code, msg)
 	}
 
 	return nil

--- a/internal/notify/wpush.go
+++ b/internal/notify/wpush.go
@@ -125,6 +125,15 @@ func (w *WPushTarget) BuildRequest(body, title string, notifyType NotifyType) (R
 }
 
 func (w *WPushTarget) Send(body, title string, notifyType NotifyType) error {
+	// Credential-bearing JSON body must not follow redirects: a 307/308 can
+	// resend apikey to another host. Keep the DispatchSend timeouts, only
+	// force followRedirect off for this request.
+	currentHTTPOptionsMu.RLock()
+	options := currentHTTPOptions
+	currentHTTPOptionsMu.RUnlock()
+	options.followRedirect = false
+	defer withHTTPOptions(options)()
+
 	spec, err := w.BuildRequest(body, title, notifyType)
 	if err != nil {
 		return err

--- a/internal/notify/wpush.go
+++ b/internal/notify/wpush.go
@@ -1,0 +1,291 @@
+package notify
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+const wpushURL = "https://api.wpush.cn/api/v1/send"
+
+const (
+	wpushChannelWeChat     = "wechat"
+	wpushChannelApp        = "app"
+	wpushChannelSMS        = "sms"
+	wpushChannelMail       = "mail"
+	wpushChannelWebhook    = "webhook"
+	wpushChannelDingTalk   = "dingtalk"
+	wpushChannelFeishu     = "feishu"
+	wpushChannelWeChatWork = "wechat_work"
+	wpushChannelClawBot    = "clawbot"
+	wpushChannelQQBot      = "qqbot"
+
+	wpushDefaultChannel = wpushChannelWeChat
+)
+
+var wpushChannels = map[string]struct{}{
+	wpushChannelWeChat:     {},
+	wpushChannelApp:        {},
+	wpushChannelSMS:        {},
+	wpushChannelMail:       {},
+	wpushChannelWebhook:    {},
+	wpushChannelDingTalk:   {},
+	wpushChannelFeishu:     {},
+	wpushChannelWeChatWork: {},
+	wpushChannelClawBot:    {},
+	wpushChannelQQBot:      {},
+}
+
+// wpushAPIKeyRe mirrors upstream Apprise: keys start with WPUSH.
+var wpushAPIKeyRe = regexp.MustCompile(`(?i)^WPUSH[a-z0-9]+$`)
+
+type WPushTarget struct {
+	apiKey    string
+	channel   string
+	topicCode string
+}
+
+func NewWPushTarget(target *ParsedURL) (*WPushTarget, error) {
+	apiKey := strings.TrimSpace(target.Host)
+	if raw, ok := target.Query["apikey"]; ok && strings.TrimSpace(raw) != "" {
+		apiKey = strings.TrimSpace(raw)
+	}
+	if apiKey == "" {
+		return nil, fmt.Errorf("missing apikey")
+	}
+	if !wpushAPIKeyRe.MatchString(apiKey) {
+		return nil, fmt.Errorf("invalid wpush apikey")
+	}
+
+	channel := wpushDefaultChannel
+	if raw := strings.TrimSpace(target.Query["channel"]); raw != "" {
+		candidate := strings.ToLower(raw)
+		if _, ok := wpushChannels[candidate]; !ok {
+			return nil, fmt.Errorf("invalid wpush channel: %q", raw)
+		}
+		channel = candidate
+	}
+
+	topicCode := strings.TrimSpace(target.Query["topic_code"])
+	if topicCode == "" {
+		topicCode = strings.TrimSpace(target.Query["to"])
+	}
+
+	return &WPushTarget{
+		apiKey:    apiKey,
+		channel:   channel,
+		topicCode: topicCode,
+	}, nil
+}
+
+type wpushPayload struct {
+	APIKey    string `json:"apikey"`
+	Title     string `json:"title"`
+	Content   string `json:"content"`
+	Channel   string `json:"channel"`
+	TopicCode string `json:"topic_code,omitempty"`
+}
+
+func (w *WPushTarget) BuildRequest(body, title string, notifyType NotifyType) (RequestSpec, error) {
+	_ = notifyType
+
+	resolvedTitle := title
+	if resolvedTitle == "" {
+		resolvedTitle = body
+	}
+
+	payload := wpushPayload{
+		APIKey:  w.apiKey,
+		Title:   resolvedTitle,
+		Content: body,
+		Channel: w.channel,
+	}
+	if w.topicCode != "" {
+		payload.TopicCode = w.topicCode
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return RequestSpec{}, err
+	}
+
+	return RequestSpec{
+		Method: "POST",
+		URL:    wpushURL,
+		Headers: map[string]string{
+			"User-Agent":   "Apprise",
+			"Accept":       "*/*",
+			"Content-Type": "application/json",
+		},
+		Body: string(data),
+	}, nil
+}
+
+func (w *WPushTarget) Send(body, title string, notifyType NotifyType) error {
+	spec, err := w.BuildRequest(body, title, notifyType)
+	if err != nil {
+		return err
+	}
+
+	var response struct {
+		Code    int    `json:"code"`
+		Message string `json:"message"`
+	}
+	if err := doJSONRequest(spec, &response); err != nil {
+		return err
+	}
+	if response.Code != 0 {
+		msg := response.Message
+		if msg == "" {
+			msg = "Unknown error"
+		}
+		return fmt.Errorf("wpush api code=%d: %s", response.Code, msg)
+	}
+
+	return nil
+}
+
+func init() {
+	RegisterSchemaEntryOrdered(169, SchemaEntry{
+		"attachment_support": false,
+		"category":           "native",
+		"details": map[string]any{
+			"args": map[string]any{
+				"apikey": map[string]any{
+					"alias_of": "apikey",
+				},
+				"channel": map[string]any{
+					"default":  wpushDefaultChannel,
+					"map_to":   "channel",
+					"name":     "Channel",
+					"private":  false,
+					"required": false,
+					"type":     "choice:string",
+					"values": []string{
+						wpushChannelWeChat,
+						wpushChannelApp,
+						wpushChannelSMS,
+						wpushChannelMail,
+						wpushChannelWebhook,
+						wpushChannelDingTalk,
+						wpushChannelFeishu,
+						wpushChannelWeChatWork,
+						wpushChannelClawBot,
+						wpushChannelQQBot,
+					},
+				},
+				"cto": map[string]any{
+					"default":  4.0,
+					"map_to":   "cto",
+					"name":     "Socket Connect Timeout",
+					"private":  false,
+					"required": false,
+					"type":     "float",
+				},
+				"emojis": map[string]any{
+					"default":  false,
+					"map_to":   "emojis",
+					"name":     "Interpret Emojis",
+					"private":  false,
+					"required": false,
+					"type":     "bool",
+				},
+				"format": map[string]any{
+					"default":  "text",
+					"map_to":   "format",
+					"name":     "Notify Format",
+					"private":  false,
+					"required": false,
+					"type":     "choice:string",
+					"values":   []string{"html", "markdown", "text"},
+				},
+				"overflow": map[string]any{
+					"default":  "upstream",
+					"map_to":   "overflow",
+					"name":     "Overflow Mode",
+					"private":  false,
+					"required": false,
+					"type":     "choice:string",
+					"values":   []string{"split", "truncate", "upstream"},
+				},
+				"rto": map[string]any{
+					"default":  4.0,
+					"map_to":   "rto",
+					"name":     "Socket Read Timeout",
+					"private":  false,
+					"required": false,
+					"type":     "float",
+				},
+				"store": map[string]any{
+					"default":  true,
+					"map_to":   "store",
+					"name":     "Persistent Storage",
+					"private":  false,
+					"required": false,
+					"type":     "bool",
+				},
+				"to": map[string]any{
+					"alias_of": "topic_code",
+				},
+				"topic_code": map[string]any{
+					"map_to":   "topic_code",
+					"name":     "Topic Code",
+					"private":  false,
+					"required": false,
+					"type":     "string",
+				},
+				"tz": map[string]any{
+					"default":  nil,
+					"map_to":   "tz",
+					"name":     "Timezone",
+					"private":  false,
+					"required": false,
+					"type":     "string",
+				},
+				"verify": map[string]any{
+					"default":  true,
+					"map_to":   "verify",
+					"name":     "Verify SSL",
+					"private":  false,
+					"required": false,
+					"type":     "bool",
+				},
+			},
+			"kwargs": map[string]any{},
+			"templates": []string{
+				"{schema}://{apikey}",
+			},
+			"tokens": map[string]any{
+				"apikey": map[string]any{
+					"map_to":   "apikey",
+					"name":     "API Key",
+					"private":  true,
+					"regex":    []string{"^WPUSH[a-z0-9]+$", "i"},
+					"required": true,
+					"type":     "string",
+				},
+				"schema": map[string]any{
+					"default":  "wpush",
+					"map_to":   "schema",
+					"name":     "Schema",
+					"private":  false,
+					"required": true,
+					"type":     "choice:string",
+					"values":   []string{"wpush"},
+				},
+			},
+		},
+		"enabled":   true,
+		"protocols": []string(nil),
+		"requirements": map[string]any{
+			"details":              "",
+			"packages_recommended": []string{},
+			"packages_required":    []string{},
+		},
+		"secure_protocols": []string{"wpush"},
+		"service_name":     "WPUSH",
+		"service_url":      "https://wpush.cn/",
+		"setup_url":        "https://wpush.cn/docs",
+	})
+}

--- a/internal/notify/wpush_test.go
+++ b/internal/notify/wpush_test.go
@@ -1,0 +1,106 @@
+package notify
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestNewWPushTarget(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := ParseURL("wpush://WPUSHabc123?channel=feishu&topic_code=topic1")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	target, err := NewWPushTarget(parsed)
+	if err != nil {
+		t.Fatalf("new target: %v", err)
+	}
+	if target.apiKey != "WPUSHabc123" {
+		t.Fatalf("apikey=%q", target.apiKey)
+	}
+	if target.channel != "feishu" {
+		t.Fatalf("channel=%q", target.channel)
+	}
+	if target.topicCode != "topic1" {
+		t.Fatalf("topic=%q", target.topicCode)
+	}
+}
+
+func TestNewWPushTargetQueryAPIKey(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := ParseURL("wpush://?apikey=WPUSHxyz99&channel=wechat")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	target, err := NewWPushTarget(parsed)
+	if err != nil {
+		t.Fatalf("new target: %v", err)
+	}
+	if target.apiKey != "WPUSHxyz99" {
+		t.Fatalf("apikey=%q", target.apiKey)
+	}
+}
+
+func TestNewWPushTargetRejectsBadKey(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := ParseURL("wpush://notavalidkey")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	if _, err := NewWPushTarget(parsed); err == nil {
+		t.Fatal("expected invalid apikey error")
+	}
+}
+
+func TestWPushBuildRequest(t *testing.T) {
+	t.Parallel()
+
+	parsed, err := ParseURL("wpush://WPUSHabc123?channel=app&to=mytopic")
+	if err != nil {
+		t.Fatalf("parse url: %v", err)
+	}
+	target, err := NewWPushTarget(parsed)
+	if err != nil {
+		t.Fatalf("new target: %v", err)
+	}
+	spec, err := target.BuildRequest("body text", "", NotifyInfo)
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	if spec.URL != wpushURL {
+		t.Fatalf("url=%q", spec.URL)
+	}
+	if spec.Method != "POST" {
+		t.Fatalf("method=%q", spec.Method)
+	}
+	if got := spec.Headers["Content-Type"]; got != "application/json" {
+		t.Fatalf("content-type=%q", got)
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(spec.Body), &payload); err != nil {
+		t.Fatalf("json: %v body=%s", err, spec.Body)
+	}
+	if payload["apikey"] != "WPUSHabc123" {
+		t.Fatalf("apikey=%v", payload["apikey"])
+	}
+	if payload["title"] != "body text" {
+		t.Fatalf("title fallback=%v", payload["title"])
+	}
+	if payload["content"] != "body text" {
+		t.Fatalf("content=%v", payload["content"])
+	}
+	if payload["channel"] != "app" {
+		t.Fatalf("channel=%v", payload["channel"])
+	}
+	if payload["topic_code"] != "mytopic" {
+		t.Fatalf("topic_code=%v", payload["topic_code"])
+	}
+	if !strings.Contains(spec.Body, `"apikey"`) {
+		t.Fatalf("body missing apikey: %s", spec.Body)
+	}
+}

--- a/internal/notify/wpush_test.go
+++ b/internal/notify/wpush_test.go
@@ -2,6 +2,8 @@ package notify
 
 import (
 	"encoding/json"
+	"io"
+	"net/http"
 	"strings"
 	"testing"
 )
@@ -102,5 +104,67 @@ func TestWPushBuildRequest(t *testing.T) {
 	}
 	if !strings.Contains(spec.Body, `"apikey"`) {
 		t.Fatalf("body missing apikey: %s", spec.Body)
+	}
+}
+
+func withMockTransport(t *testing.T, roundTrip func(*http.Request) (*http.Response, error)) func() {
+	t.Helper()
+	previous := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(roundTrip)
+	return func() { http.DefaultTransport = previous }
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+func TestWPushSendCode0DespiteNon2xx(t *testing.T) {
+	restore := withMockTransport(t, func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Status:     "201 Created",
+			Body:       io.NopCloser(strings.NewReader(`{"code":0,"message":"ok"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+	defer restore()
+
+	parsed, err := ParseURL("wpush://WPUSHabc123")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	target, err := NewWPushTarget(parsed)
+	if err != nil {
+		t.Fatalf("target: %v", err)
+	}
+	if err := target.Send("body", "title", NotifyInfo); err != nil {
+		t.Fatalf("expected success on non-2xx with code 0: %v", err)
+	}
+}
+
+func TestWPushSendRejectsBooleanCode(t *testing.T) {
+	// Regression: Python treats False == 0; Go must still fail on {"code":false}.
+	restore := withMockTransport(t, func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(`{"code":false,"message":"nope"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+	defer restore()
+
+	parsed, err := ParseURL("wpush://WPUSHabc123")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	target, err := NewWPushTarget(parsed)
+	if err != nil {
+		t.Fatalf("target: %v", err)
+	}
+	if err := target.Send("body", "title", NotifyInfo); err == nil {
+		t.Fatal("expected failure for boolean code")
 	}
 }

--- a/internal/notify/wpush_test.go
+++ b/internal/notify/wpush_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -251,5 +252,39 @@ func TestWPushSendRejectsNonZeroCode(t *testing.T) {
 	}
 	if err := target.Send("body", "title", NotifyInfo); err == nil {
 		t.Fatal("expected failure for nonzero code")
+	}
+}
+
+func TestWPushSendDoesNotFollowRedirects(t *testing.T) {
+	var hits atomic.Int32
+	restore := withMockTransport(t, func(req *http.Request) (*http.Response, error) {
+		hits.Add(1)
+		if hits.Load() > 1 {
+			t.Fatal("client followed redirect and re-sent request")
+		}
+		header := make(http.Header)
+		header.Set("Location", "https://evil.example/steal")
+		return &http.Response{
+			StatusCode: http.StatusTemporaryRedirect,
+			Status:     "307 Temporary Redirect",
+			Body:       io.NopCloser(strings.NewReader(`{"code":0,"message":"redirect"}`)),
+			Header:     header,
+			Request:    req,
+		}, nil
+	})
+	defer restore()
+
+	parsed, err := ParseURL("wpush://WPUSHabc123")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	target, err := NewWPushTarget(parsed)
+	if err != nil {
+		t.Fatalf("target: %v", err)
+	}
+	// Even if body claims code 0, we must not have followed; one hit is enough.
+	_ = target.Send("body", "title", NotifyInfo)
+	if hits.Load() != 1 {
+		t.Fatalf("hits=%d want 1", hits.Load())
 	}
 }

--- a/internal/notify/wpush_test.go
+++ b/internal/notify/wpush_test.go
@@ -168,3 +168,88 @@ func TestWPushSendRejectsBooleanCode(t *testing.T) {
 		t.Fatal("expected failure for boolean code")
 	}
 }
+
+func TestWPushSendAcceptsExplicitCode0(t *testing.T) {
+	restore := withMockTransport(t, func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(`{"code":0,"message":"ok"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+	defer restore()
+
+	parsed, err := ParseURL("wpush://WPUSHabc123")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	target, err := NewWPushTarget(parsed)
+	if err != nil {
+		t.Fatalf("target: %v", err)
+	}
+	if err := target.Send("body", "title", NotifyInfo); err != nil {
+		t.Fatalf("expected success for explicit code 0: %v", err)
+	}
+}
+
+func TestWPushSendRejectsMissingCode(t *testing.T) {
+	for _, body := range []string{
+		`{}`,
+		`{"message":"rejected"}`,
+		`{"code":null,"message":"null code"}`,
+		`null`,
+	} {
+		body := body
+		t.Run(body, func(t *testing.T) {
+			restore := withMockTransport(t, func(req *http.Request) (*http.Response, error) {
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Status:     "200 OK",
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     make(http.Header),
+					Request:    req,
+				}, nil
+			})
+			defer restore()
+
+			parsed, err := ParseURL("wpush://WPUSHabc123")
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			target, err := NewWPushTarget(parsed)
+			if err != nil {
+				t.Fatalf("target: %v", err)
+			}
+			if err := target.Send("body", "title", NotifyInfo); err == nil {
+				t.Fatalf("expected failure for body %s", body)
+			}
+		})
+	}
+}
+
+func TestWPushSendRejectsNonZeroCode(t *testing.T) {
+	restore := withMockTransport(t, func(req *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Status:     "200 OK",
+			Body:       io.NopCloser(strings.NewReader(`{"code":401,"message":"bad key"}`)),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	})
+	defer restore()
+
+	parsed, err := ParseURL("wpush://WPUSHabc123")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	target, err := NewWPushTarget(parsed)
+	if err != nil {
+		t.Fatalf("target: %v", err)
+	}
+	if err := target.Send("body", "title", NotifyInfo); err == nil {
+		t.Fatal("expected failure for nonzero code")
+	}
+}

--- a/internal/parity/provider_registry_test.go
+++ b/internal/parity/provider_registry_test.go
@@ -327,6 +327,9 @@ var providerBuilders = map[string]buildTargetFunc{
 	"pushplus": func(parsed *notify.ParsedURL) (requestSender, error) {
 		return notify.NewPushplusTarget(parsed)
 	},
+	"wpush": func(parsed *notify.ParsedURL) (requestSender, error) {
+		return notify.NewWPushTarget(parsed)
+	},
 	"smtp2go": func(parsed *notify.ParsedURL) (requestSender, error) {
 		return notify.NewSMTP2GoTarget(parsed)
 	},

--- a/internal/parity/providers/wpush/cases.json
+++ b/internal/parity/providers/wpush/cases.json
@@ -1,0 +1,30 @@
+[
+  {
+    "name": "default",
+    "url": "wpush://WPUSHabc123def456",
+    "body": "hello from parity",
+    "title": "apprise parity",
+    "type": "info"
+  },
+  {
+    "name": "title-fallback",
+    "url": "wpush://WPUSHabc123def456",
+    "body": "hello",
+    "title": "",
+    "type": "info"
+  },
+  {
+    "name": "channel-topic",
+    "url": "wpush://WPUSHabc123def456?channel=feishu&topic_code=demo",
+    "body": "topic body",
+    "title": "topic title",
+    "type": "info"
+  },
+  {
+    "name": "query-apikey",
+    "url": "wpush://?apikey=WPUSHabc123def456&channel=app",
+    "body": "query key body",
+    "title": "query key",
+    "type": "info"
+  }
+]

--- a/internal/parity/providers/wpush/golden.json
+++ b/internal/parity/providers/wpush/golden.json
@@ -1,0 +1,62 @@
+[
+  {
+    "name": "default",
+    "requests": [
+      {
+        "method": "POST",
+        "url": "https://api.wpush.cn/api/v1/send",
+        "headers": {
+          "accept": "*/*",
+          "content-type": "application/json",
+          "user-agent": "Apprise"
+        },
+        "body": "{\"apikey\":\"WPUSHabc123def456\",\"title\":\"apprise parity\",\"content\":\"hello from parity\",\"channel\":\"wechat\"}"
+      }
+    ]
+  },
+  {
+    "name": "title-fallback",
+    "requests": [
+      {
+        "method": "POST",
+        "url": "https://api.wpush.cn/api/v1/send",
+        "headers": {
+          "accept": "*/*",
+          "content-type": "application/json",
+          "user-agent": "Apprise"
+        },
+        "body": "{\"apikey\":\"WPUSHabc123def456\",\"title\":\"hello\",\"content\":\"hello\",\"channel\":\"wechat\"}"
+      }
+    ]
+  },
+  {
+    "name": "channel-topic",
+    "requests": [
+      {
+        "method": "POST",
+        "url": "https://api.wpush.cn/api/v1/send",
+        "headers": {
+          "accept": "*/*",
+          "content-type": "application/json",
+          "user-agent": "Apprise"
+        },
+        "body": "{\"apikey\":\"WPUSHabc123def456\",\"title\":\"topic title\",\"content\":\"topic body\",\"channel\":\"feishu\",\"topic_code\":\"demo\"}"
+      }
+    ]
+  },
+  {
+    "name": "query-apikey",
+    "requests": [
+      {
+        "method": "POST",
+        "url": "https://api.wpush.cn/api/v1/send",
+        "headers": {
+          "accept": "*/*",
+          "content-type": "application/json",
+          "user-agent": "Apprise"
+        },
+        "body": "{\"apikey\":\"WPUSHabc123def456\",\"title\":\"query key\",\"content\":\"query key body\",\"channel\":\"app\"}"
+      }
+    ]
+  }
+]

--- a/internal/parity/providers/wpush/manifest.json
+++ b/internal/parity/providers/wpush/manifest.json
@@ -1,0 +1,6 @@
+{
+  "name": "wpush",
+  "schemas": [
+    "wpush"
+  ]
+}

--- a/internal/parity/providers/wpush/response_reject.json
+++ b/internal/parity/providers/wpush/response_reject.json
@@ -7,10 +7,24 @@
     "reason": "JSON false must not equal numeric 0"
   },
   {
+    "name": "reject-missing-code",
+    "status": 200,
+    "body": {"message": "rejected"},
+    "expect_success": false,
+    "reason": "missing code must not default to success"
+  },
+  {
+    "name": "reject-null-code",
+    "status": 200,
+    "body": {"code": null, "message": "null code"},
+    "expect_success": false,
+    "reason": "null code must not default to success"
+  },
+  {
     "name": "accept-code-0-non-2xx",
     "status": 201,
     "body": {"code": 0, "message": "ok"},
     "expect_success": true,
-    "reason": "WPUSH success is application code === 0"
+    "reason": "WPUSH success is explicit application code === 0"
   }
 ]

--- a/internal/parity/providers/wpush/response_reject.json
+++ b/internal/parity/providers/wpush/response_reject.json
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "reject-boolean-code",
+    "status": 200,
+    "body": {"code": false, "message": "nope"},
+    "expect_success": false,
+    "reason": "JSON false must not equal numeric 0"
+  },
+  {
+    "name": "accept-code-0-non-2xx",
+    "status": 201,
+    "body": {"code": 0, "message": "ok"},
+    "expect_success": true,
+    "reason": "WPUSH success is application code === 0"
+  }
+]

--- a/internal/parity/upstream_plugins/wpush.py
+++ b/internal/parity/upstream_plugins/wpush.py
@@ -241,7 +241,8 @@ class NotifyWPush(NotifyBase):
                 return False
 
             api_code = content.get("code")
-            if api_code != 0:
+            # json.loads maps JSON false -> False, and False == 0 in Python.
+            if isinstance(api_code, bool) or api_code != 0:
                 error_str = content.get("message", "Unknown error")
                 status_str = NotifyWPush.http_response_code_lookup(
                     r.status_code

--- a/internal/parity/upstream_plugins/wpush.py
+++ b/internal/parity/upstream_plugins/wpush.py
@@ -195,62 +195,70 @@ class NotifyWPush(NotifyBase):
             self.notify_url,
             self.verify_certificate,
         )
-        self.logger.debug("WPUSH Payload: %r", payload)
+        # Never log apikey; keep a redacted payload for diagnostics.
+        safe_payload = dict(payload)
+        if "apikey" in safe_payload:
+            safe_payload["apikey"] = self.pprint(
+                self.apikey, privacy=True, mode=PrivacyMode.Secret, safe=""
+            )
+        self.logger.debug("WPUSH Payload: %r", safe_payload)
 
         self.throttle()
 
         try:
+            # Credential-bearing JSON body must not follow redirects.
             r = requests.post(
                 self.notify_url,
                 headers=headers,
                 data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
                 verify=self.verify_certificate,
                 timeout=self.request_timeout,
-                allow_redirects=self.redirects,
+                allow_redirects=False,
             )
-
-            if r.status_code != requests.codes.ok:
-                status_str = NotifyWPush.http_response_code_lookup(
-                    r.status_code
-                )
-                self.logger.warning(
-                    "Failed to send WPUSH notification: "
-                    "{}{}error={}.".format(
-                        status_str,
-                        ", " if status_str else "",
-                        r.status_code,
-                    )
-                )
-                self.logger.debug(
-                    "Response Details:\r\n%r",
-                    (r.content or b"")[:2000],
-                )
-                return False
 
             try:
                 content = json.loads(r.content)
             except (AttributeError, TypeError, ValueError):
-                content = {}
+                content = None
                 self.logger.debug(
                     "Failed to parse WPUSH JSON response; body: %r",
                     (r.content or b"")[:2000],
                 )
 
-            # WPUSH success is code === 0 (not PushPlus's 200)
-            api_code = content.get("code") if content else None
-            if api_code != 0:
-                error_str = (
-                    content.get("message", "Unknown error")
-                    if content
-                    else "Unknown error"
+            # Success is JSON code === 0 (HTTP status is diagnostic only).
+            if not isinstance(content, dict):
+                status_str = NotifyWPush.http_response_code_lookup(
+                    r.status_code
                 )
                 self.logger.warning(
                     "Failed to send WPUSH notification: "
-                    "code={}: {}.".format(api_code, error_str)
+                    "invalid JSON root{}{}error={}.".format(
+                        ", " if status_str else "",
+                        status_str,
+                        r.status_code,
+                    )
+                )
+                return False
+
+            api_code = content.get("code")
+            if api_code != 0:
+                error_str = content.get("message", "Unknown error")
+                status_str = NotifyWPush.http_response_code_lookup(
+                    r.status_code
+                )
+                self.logger.warning(
+                    "Failed to send WPUSH notification: "
+                    "code={}: {}{}{}error={}.".format(
+                        api_code,
+                        error_str,
+                        ", " if status_str else "",
+                        status_str,
+                        r.status_code,
+                    )
                 )
                 self.logger.debug(
                     "Response Details:\r\n%r",
-                    content if content else (r.content or b"")[:2000],
+                    content,
                 )
                 return False
 

--- a/internal/parity/upstream_plugins/wpush.py
+++ b/internal/parity/upstream_plugins/wpush.py
@@ -1,0 +1,339 @@
+#
+# BSD 2-Clause License
+#
+# Apprise - Push Notification Library.
+# Copyright (c) 2026, Chris Caron <lead2gold@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+# WPUSH is a Chinese multi-channel push platform (WeChat, App, SMS, email,
+# DingTalk, Feishu, WeCom, webhook, and more). Docs: https://wpush.cn/docs
+#
+# Obtain your API Key from https://wpush.cn/settings (starts with WPUSH).
+# Bind at least one channel at https://wpush.cn/channels before sending.
+#
+# Apprise URL forms:
+#   wpush://{apikey}
+#   wpush://{apikey}?channel=wechat
+#   wpush://{apikey}?channel=feishu&topic_code={code}
+#   wpush://?apikey={apikey}
+#
+# Native API URL (also accepted):
+#   https://api.wpush.cn/api/v1/send?apikey={apikey}
+#
+# Success is JSON code === 0 (unlike PushPlus which uses code 200).
+
+import json
+import re
+
+import requests
+
+from ..common import NotifyType
+from ..locale import gettext_lazy as _
+from ..url import PrivacyMode
+from ..utils.parse import validate_regex
+from .base import NotifyBase
+
+
+class WPushChannel:
+    """WPUSH delivery channels."""
+
+    WECHAT = "wechat"
+    APP = "app"
+    SMS = "sms"
+    MAIL = "mail"
+    WEBHOOK = "webhook"
+    DINGTALK = "dingtalk"
+    FEISHU = "feishu"
+    WECHAT_WORK = "wechat_work"
+    CLAWBOT = "clawbot"
+    QQBOT = "qqbot"
+
+
+WPUSH_CHANNELS = (
+    WPushChannel.WECHAT,
+    WPushChannel.APP,
+    WPushChannel.SMS,
+    WPushChannel.MAIL,
+    WPushChannel.WEBHOOK,
+    WPushChannel.DINGTALK,
+    WPushChannel.FEISHU,
+    WPushChannel.WECHAT_WORK,
+    WPushChannel.CLAWBOT,
+    WPushChannel.QQBOT,
+)
+
+WPUSH_CHANNEL_DEFAULT = WPushChannel.WECHAT
+
+
+class NotifyWPush(NotifyBase):
+    """A wrapper for WPUSH Notifications."""
+
+    service_name = "WPUSH"
+
+    service_url = "https://wpush.cn/"
+
+    secure_protocol = "wpush"
+
+    setup_url = "https://wpush.cn/docs"
+
+    notify_url = "https://api.wpush.cn/api/v1/send"
+
+    # Practical caps aligned with WPUSH open API docs
+    body_maxlen = 10000
+    title_maxlen = 255
+
+    templates = ("{schema}://{apikey}",)
+
+    template_tokens = dict(
+        NotifyBase.template_tokens,
+        **{
+            "apikey": {
+                "name": _("API Key"),
+                "type": "string",
+                "private": True,
+                "required": True,
+                # Keys start with WPUSH followed by alphanumeric characters
+                "regex": (r"^WPUSH[a-z0-9]+$", "i"),
+            },
+        },
+    )
+
+    template_args = dict(
+        NotifyBase.template_args,
+        **{
+            "apikey": {
+                "alias_of": "apikey",
+            },
+            "channel": {
+                "name": _("Channel"),
+                "type": "choice:string",
+                "values": WPUSH_CHANNELS,
+                "default": WPUSH_CHANNEL_DEFAULT,
+            },
+            "topic_code": {
+                "name": _("Topic Code"),
+                "type": "string",
+            },
+            # Convenience alias used elsewhere in Apprise
+            "to": {
+                "alias_of": "topic_code",
+            },
+        },
+    )
+
+    def __init__(self, apikey, channel=None, topic_code=None, **kwargs):
+        """Initialize WPUSH Object."""
+        super().__init__(**kwargs)
+
+        self.apikey = validate_regex(
+            apikey, *self.template_tokens["apikey"]["regex"]
+        )
+        if not self.apikey:
+            msg = "The WPUSH API Key ({}) is invalid.".format(apikey)
+            self.logger.warning(msg)
+            raise TypeError(msg)
+
+        if channel:
+            self.channel = next(
+                (c for c in WPUSH_CHANNELS if c == channel.lower()),
+                None,
+            )
+            if not self.channel:
+                msg = "The WPUSH channel ({}) is not valid.".format(channel)
+                self.logger.warning(msg)
+                raise TypeError(msg)
+        else:
+            self.channel = WPUSH_CHANNEL_DEFAULT
+
+        self.topic_code = (
+            topic_code
+            if isinstance(topic_code, str) and topic_code.strip()
+            else None
+        )
+
+    def send(self, body, title="", notify_type=NotifyType.INFO, **kwargs):
+        """Perform WPUSH Notification."""
+
+        headers = {
+            "User-Agent": self.app_id,
+            "Content-Type": "application/json",
+        }
+
+        payload = {
+            "apikey": self.apikey,
+            # title is required by WPUSH; fall back to body when empty
+            "title": title if title else body,
+            "content": body,
+            "channel": self.channel,
+        }
+        if self.topic_code:
+            payload["topic_code"] = self.topic_code
+
+        self.logger.debug(
+            "WPUSH POST URL: %s (cert_verify=%r)",
+            self.notify_url,
+            self.verify_certificate,
+        )
+        self.logger.debug("WPUSH Payload: %r", payload)
+
+        self.throttle()
+
+        try:
+            r = requests.post(
+                self.notify_url,
+                headers=headers,
+                data=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                verify=self.verify_certificate,
+                timeout=self.request_timeout,
+                allow_redirects=self.redirects,
+            )
+
+            if r.status_code != requests.codes.ok:
+                status_str = NotifyWPush.http_response_code_lookup(
+                    r.status_code
+                )
+                self.logger.warning(
+                    "Failed to send WPUSH notification: "
+                    "{}{}error={}.".format(
+                        status_str,
+                        ", " if status_str else "",
+                        r.status_code,
+                    )
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r",
+                    (r.content or b"")[:2000],
+                )
+                return False
+
+            try:
+                content = json.loads(r.content)
+            except (AttributeError, TypeError, ValueError):
+                content = {}
+                self.logger.debug(
+                    "Failed to parse WPUSH JSON response; body: %r",
+                    (r.content or b"")[:2000],
+                )
+
+            # WPUSH success is code === 0 (not PushPlus's 200)
+            api_code = content.get("code") if content else None
+            if api_code != 0:
+                error_str = (
+                    content.get("message", "Unknown error")
+                    if content
+                    else "Unknown error"
+                )
+                self.logger.warning(
+                    "Failed to send WPUSH notification: "
+                    "code={}: {}.".format(api_code, error_str)
+                )
+                self.logger.debug(
+                    "Response Details:\r\n%r",
+                    content if content else (r.content or b"")[:2000],
+                )
+                return False
+
+        except requests.RequestException as e:
+            self.logger.warning(
+                "A Connection error occurred sending WPUSH notification."
+            )
+            self.logger.debug("Socket Exception: %s", str(e))
+            return False
+
+        self.logger.info("Sent WPUSH notification.")
+        return True
+
+    @property
+    def url_identifier(self):
+        """Returns identifiers that make this URL unique."""
+        return (self.secure_protocol, self.apikey)
+
+    def url(self, privacy=False, *args, **kwargs):
+        """Returns the URL built dynamically based on specified arguments."""
+        params = {}
+        if self.channel != WPUSH_CHANNEL_DEFAULT:
+            params["channel"] = self.channel
+        if self.topic_code:
+            params["topic_code"] = self.topic_code
+        params.update(self.url_parameters(privacy=privacy, *args, **kwargs))
+
+        return "{schema}://{apikey}/?{params}".format(
+            schema=self.secure_protocol,
+            apikey=self.pprint(
+                self.apikey, privacy, mode=PrivacyMode.Secret, safe=""
+            ),
+            params=NotifyWPush.urlencode(params),
+        )
+
+    @staticmethod
+    def parse_url(url):
+        """Parses the URL and returns enough arguments to re-instantiate."""
+        results = NotifyBase.parse_url(url, verify_host=False)
+        if not results:
+            return results
+
+        if "apikey" in results["qsd"] and results["qsd"]["apikey"]:
+            results["apikey"] = NotifyWPush.unquote(results["qsd"]["apikey"])
+        else:
+            results["apikey"] = NotifyWPush.unquote(results["host"])
+
+        if "channel" in results["qsd"] and results["qsd"]["channel"]:
+            results["channel"] = NotifyWPush.unquote(results["qsd"]["channel"])
+
+        if "topic_code" in results["qsd"] and results["qsd"]["topic_code"]:
+            results["topic_code"] = NotifyWPush.unquote(
+                results["qsd"]["topic_code"]
+            )
+        elif "to" in results["qsd"] and results["qsd"]["to"]:
+            results["topic_code"] = NotifyWPush.unquote(results["qsd"]["to"])
+
+        return results
+
+    @staticmethod
+    def parse_native_url(url):
+        """Support native WPUSH API URLs:
+        https://api.wpush.cn/api/v1/send?apikey=KEY[&channel=…]
+        """
+        result = re.match(
+            r"^https?://api\.wpush\.cn/api/v1/send"
+            r"(?:\?(?P<params>[^#]+))?$",
+            url,
+            re.I,
+        )
+        if result:
+            params = result.group("params") or ""
+            key = re.search(
+                r"(?:(?:^|&))apikey=(?P<apikey>[^&]+)",
+                params,
+                re.I,
+            )
+            if key:
+                return NotifyWPush.parse_url(
+                    "{schema}://{apikey}/?{params}".format(
+                        schema=NotifyWPush.secure_protocol,
+                        apikey=NotifyWPush.unquote(key.group("apikey")),
+                        params=params,
+                    )
+                )
+        return None

--- a/internal/testutil/request_capture.go
+++ b/internal/testutil/request_capture.go
@@ -56,7 +56,10 @@ func (c *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) 
 
 	responseBody := "ok"
 	contentType := "text/plain"
-	if strings.Contains(req.URL.String(), "sendpulse.com/oauth/access_token") {
+	if req.URL.Host == "api.wpush.cn" && strings.HasPrefix(req.URL.Path, "/api/v1/send") {
+		responseBody = `{"code":0,"message":"ok"}`
+		contentType = "application/json"
+	} else if strings.Contains(req.URL.String(), "sendpulse.com/oauth/access_token") {
 		responseBody = `{"access_token":"token","expires_in":3600}`
 		contentType = "application/json"
 	} else if strings.Contains(req.URL.Path, "/api/v4/teams/") && strings.Contains(req.URL.Path, "/channels/name/") {

--- a/internal/testutil/scripts/capture_request.py
+++ b/internal/testutil/scripts/capture_request.py
@@ -867,6 +867,9 @@ def capture_request(url, body, title, notify_type, body_format=None, attach=None
             response._content = b'{"code":1000,"msg":"ok"}'
         elif parsed.netloc == "www.pushplus.plus" and parsed.path == "/send":
             response._content = b'{"code":200,"msg":"ok"}'
+        elif parsed.netloc == "api.wpush.cn" and parsed.path.startswith("/api/v1/send"):
+            # WPUSH success is JSON code === 0
+            response._content = b'{"code":0,"message":"ok"}'
         elif parsed.netloc == "api2.serwersms.pl" and "/messages/" in parsed.path:
             # SerwerSMS answers 200 and reports the outcome in the body
             response._content = b'{"success":true}'

--- a/scripts/ci/setup_parity_env.sh
+++ b/scripts/ci/setup_parity_env.sh
@@ -12,3 +12,13 @@ if [[ -f ../apprise/pyproject.toml ]]; then
 else
   python -m pip install "apprise[all-plugins]"
 fi
+
+# Forward-port plugins not yet released in tagged Apprise (kept in
+# internal/parity/upstream_plugins/). Drop once the matching upstream
+# Apprise release includes them.
+plugin_src="internal/parity/upstream_plugins/wpush.py"
+if [[ -f "${plugin_src}" ]]; then
+  plugin_dst="$(python -c 'import apprise, pathlib; print(pathlib.Path(apprise.__file__).resolve().parent / "plugins")')"
+  cp "${plugin_src}" "${plugin_dst}/wpush.py"
+  echo "Installed forward-port plugin: ${plugin_dst}/wpush.py"
+fi


### PR DESCRIPTION
## Summary
- Add `wpush://` provider aligned with [caronc/apprise#1721](https://github.com/caronc/apprise/pull/1721)
- `POST https://api.wpush.cn/api/v1/send` with `apikey` / `title` / `content` / `channel` / optional `topic_code`
- Success when JSON `code === 0` (not HTTP-only)
- URL forms: `wpush://{apikey}`, `wpush://{apikey}?channel=…&topic_code=…`, `wpush://?apikey=…`
- Parity fixtures + capture stubs; temporary Python forward-port under `internal/parity/upstream_plugins/` for CI until Apprise ships WPUSH

## Test plan
- [x] `go test ./internal/notify -run TestNewWPush|TestWPush|TestSchemaEntries|TestSecureSchemes`
- [x] `go test ./internal/parity -run 'TestProviderGoldenRequests/wpush|TestProviderManifests|TestProviderBuilders'`
- [ ] CI parity.yml (uses forward-ported `wpush.py` via `setup_parity_env.sh`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added WPUSH push notification support through the `wpush://` URL scheme.
  - Supports API key authentication, configurable channels, topic codes, titles, and message content.
  - Supports channels including WeChat, Feishu, DingTalk, email, SMS, webhooks, and more.
  - Reports failed requests and unsuccessful API responses while recognizing explicit WPUSH success responses regardless of HTTP status.

- **Tests**
  - Added coverage for URL parsing, validation, request construction, response handling, and provider parity scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->